### PR TITLE
Remove creds json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- added setup.cfg for wheels
+
+### Removed
+- Removed unneeded creds file generation.
+
+## [0.3.0] - 2016-08-11
+### Added
 - Added `requirements-*.txt` files.  The `-prod` files have pinned versions+hashes, via `reqhash`.
 - Added `raise_future_exceptions` function from signingscript
 

--- a/scriptworker/context.py
+++ b/scriptworker/context.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 import json
 import logging
 import os
-import time
 
 from scriptworker.utils import makedirs
 from taskcluster.async import Queue
@@ -101,10 +100,6 @@ class Context(object):
         """
         self._reclaim_task = value
         if value is not None:
-            path = os.path.join(self.config['work_dir'],
-                                "reclaim_task.{}.json".format(time.time()))
-            self.write_json(path, value, "Writing reclaim_task file to {path}...")
-            # XXX we may not need the reclaim_task.json or credentials.json...
             self.temp_credentials = value['credentials']
 
     @property
@@ -119,15 +114,9 @@ class Context(object):
     def temp_credentials(self, credentials):
         """Set the temp_credentials from the latest claimTask or reclaimTask
         call.
-
-        Write these to disk with a timestamp so we can try to avoid i/o race
-        conditions.
         """
         self._temp_credentials = credentials
         self.temp_queue = self.create_queue(self.temp_credentials)
-        path = os.path.join(self.config['work_dir'],
-                            "credentials.{}.json".format(time.time()))
-        self.write_json(path, credentials, "Writing credentials file to {path}...")
 
     def write_json(self, path, contents, message):
         """Write json to disk.

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -2,7 +2,6 @@
 # coding=utf-8
 """Test scriptworker.context
 """
-import glob
 import json
 import os
 import pytest
@@ -41,18 +40,6 @@ def reclaim_task():
     }
 
 
-def get_credentials_files(context):
-    temp_dir = context.config['work_dir']
-    files = sorted(glob.glob(os.path.join(temp_dir, "credentials.*.json")))
-    return files
-
-
-def get_reclaim_task_files(context):
-    temp_dir = context.config['work_dir']
-    files = sorted(glob.glob(os.path.join(temp_dir, "reclaim_task.*.json")))
-    return files
-
-
 def get_task_file(context):
     temp_dir = context.config['work_dir']
     path = os.path.join(temp_dir, "task.json")
@@ -76,11 +63,7 @@ class TestContext(object):
         assert context.claim_task == claim_task
         assert context.reclaim_task is None
         assert context.temp_credentials == claim_task['credentials']
-        assert get_reclaim_task_files(context) == []
         assert get_json(get_task_file(context)) == claim_task['task']
-        files = get_credentials_files(context)
-        assert len(files) == 1, "Invalid number of credentials files!"
-        assert get_json(files[0]) == claim_task['credentials']
 
     def test_set_reclaim_task(self, context, claim_task, reclaim_task):
         context.claim_task = claim_task
@@ -90,13 +73,6 @@ class TestContext(object):
         assert context.reclaim_task == reclaim_task
         assert context.temp_credentials == reclaim_task['credentials']
         assert get_json(get_task_file(context)) == claim_task['task']
-        files = get_reclaim_task_files(context)
-        assert len(files) == 1, "Invalid number of reclaim_task files!"
-        assert get_json(files[0]) == reclaim_task
-        files = get_credentials_files(context)
-        assert len(files) == 2, "Invalid number of credentials files!"
-        assert get_json(files[0]) == claim_task['credentials']
-        assert get_json(files[1]) == reclaim_task['credentials']
 
     def test_set_reset_task(self, context, claim_task, reclaim_task):
         context.claim_task = claim_task


### PR DESCRIPTION
Once upon a time I thought the scripts run in scriptworker would need the temporary credentials and reclaim_task info from TaskCluster.  Neither signingscript nor funsize-balrogworker need them; let's remove that functionality until we have good need for it.
