### PR TITLE
add `validate_artifact_url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - added setup.cfg for wheels
+- added `scriptworker.client.validate_artifact_url`
 
 ### Removed
 - Removed unneeded creds file generation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - added setup.cfg for wheels
-- added `scriptworker.client.validate_artifact_url`
+- added `scriptworker.client.validate_artifact_url`.
+
+### Changed
+- test files no longer use a test class.
 
 ### Removed
 - Removed unneeded creds file generation.

--- a/config_example.json
+++ b/config_example.json
@@ -11,6 +11,9 @@
     "artifact_upload_timeout": 1200,
     "task_script": ["bash", "-c", "echo foo && sleep 19 && exit 1"],
     "task_max_timeout": 1200,
+    "valid_artifact_schemes": ["https"],
+    "valid_artifact_netlocs": ["queue.taskcluster.net"],
+    "valid_artifact_path_regexes": ["^/v1/task/(?P<taskId>[^/]+)/artifacts/(?P<filepath>.*)$"],
 
     "credentials": {
         "clientId": "...",

--- a/scriptworker/client.py
+++ b/scriptworker/client.py
@@ -128,7 +128,7 @@ def validate_artifact_url(config, url):
             parts.netloc not in validate_config['valid_artifact_netlocs']:
         messages.append('Invalid netloc: {}!'.format(parts.netloc))
     # check the paths
-    for regex in validate_config.get('valid_artifact_path_regexes', []):
+    for regex in validate_config.get('valid_artifact_path_regexes') or []:
         m = re.search(regex, parts.path)
         if m is None:
             continue
@@ -144,14 +144,15 @@ def validate_artifact_url(config, url):
         return_value = path_info['filepath']
         break
     else:
-        messages.append('Invalid path: {}!'.format(parts.path))
+        if validate_config.get('valid_artifact_path_regexes'):
+            messages.append('Invalid path: {}!'.format(parts.path))
 
     if messages:
         raise ScriptWorkerTaskException(
             "Can't validate url {}\n{}".format(url, messages),
             exit_code=STATUSES['malformed-payload']
         )
-    return return_value
+    return return_value.lstrip('/')
 
 
 def integration_create_task_payload(config, task_group_id, scopes=None,

--- a/scriptworker/client.py
+++ b/scriptworker/client.py
@@ -7,6 +7,10 @@ import glob
 import json
 import jsonschema
 import os
+import re
+from urllib.parse import urlparse
+
+from scriptworker.config import DEFAULT_CONFIG
 from scriptworker.exceptions import ScriptWorkerTaskException
 from scriptworker.task import STATUSES
 from scriptworker.utils import retry_async
@@ -82,6 +86,72 @@ def validate_task_schema(task, schema):
             "Can't validate task schema!\n{}".format(str(exc)),
             exit_code=STATUSES['malformed-payload']
         )
+
+
+def validate_artifact_url(config, url):
+    """Ensure a URL fits in given scheme, netloc, and path restrictions.
+
+    If `valid_artifact_schemes`, `valid_artifact_netlocs`, and/or
+    `valid_artifact_path_regexes` are defined in `config` but are `None`,
+    skip that check.
+
+    If any are missing from `config`, fall back to the values in
+    `DEFAULT_CONFIG`.
+
+    If `valid_artifact_path_regexes` is not None, the url path should
+    match one.  Each regex should define a `filepath`, which is what we'll
+    return.
+
+    Otherwise, if we pass all checks, return the unmodified path.
+
+    If we fail any checks, raise a ScriptWorkerTaskException with
+    `malformed-payload`.
+    """
+    messages = []
+    validate_config = {}
+    for key in (
+        'valid_artifact_schemes', 'valid_artifact_netlocs',
+        'valid_artifact_path_regexes', 'valid_artifact_task_ids',
+    ):
+        if key in config:
+            validate_config[key] = config[key]
+        else:
+            validate_config[key] = DEFAULT_CONFIG[key]
+    parts = urlparse(url)
+    return_value = parts.path
+    # scheme whitelisted?
+    if validate_config['valid_artifact_schemes'] is not None and \
+            parts.scheme not in validate_config['valid_artifact_schemes']:
+        messages.append('Invalid scheme: {}!'.format(parts.scheme))
+    # netloc whitelisted?
+    if validate_config['valid_artifact_netlocs'] is not None and \
+            parts.netloc not in validate_config['valid_artifact_netlocs']:
+        messages.append('Invalid netloc: {}!'.format(parts.netloc))
+    # check the paths
+    for regex in validate_config.get('valid_artifact_path_regexes', []):
+        m = re.search(regex, parts.path)
+        if m is None:
+            continue
+        path_info = m.groupdict()
+        # make sure we're pointing at a valid task ID
+        if 'taskId' in path_info and \
+                path_info['taskId'] not in validate_config['valid_artifact_task_ids']:
+            messages.append('Invalid taskId: {}!'.format(path_info['taskId']))
+            break
+        if 'filepath' not in path_info:
+            messages.append('Invalid regex {}!'.format(regex))
+            break
+        return_value = path_info['filepath']
+        break
+    else:
+        messages.append('Invalid path: {}!'.format(parts.path))
+
+    if messages:
+        raise ScriptWorkerTaskException(
+            "Can't validate url {}\n{}".format(url, messages),
+            exit_code=STATUSES['malformed-payload']
+        )
+    return return_value
 
 
 def integration_create_task_payload(config, task_group_id, scopes=None,

--- a/scriptworker/config.py
+++ b/scriptworker/config.py
@@ -24,11 +24,19 @@ DEFAULT_CONFIG = {
         "certificate": "...",
     },
 
+    # for download url validation.  The regexes need to define a 'filepath'.
+    'valid_artifact_schemes': ('https', ),
+    'valid_artifact_netlocs': ('queue.taskcluster.net', ),
+    'valid_artifact_path_regexes': (
+        r'''^/v1/task/(?P<taskId>[^/]+)/artifacts/(?P<filepath>.*)$''',
+    ),
+    'valid_artifact_task_ids': (),
+
     # Worker settings; these probably don't need tweaking
     "max_connections": 30,
     "credential_update_interval": 300,
     "reclaim_interval": 300,
-    "poll_interval": 5,  # TODO 1 ?
+    "poll_interval": 5,
 
     # Worker log settings
     "log_datefmt": "%Y-%m-%dT%H:%M:%S",

--- a/scriptworker/context.py
+++ b/scriptworker/context.py
@@ -121,8 +121,7 @@ class Context(object):
     def write_json(self, path, contents, message):
         """Write json to disk.
         """
-        if contents:
-            log.debug(message.format(path=path))
-            makedirs(os.path.dirname(path))
-            with open(path, "w") as fh:
-                json.dump(contents, fh, indent=2, sort_keys=True)
+        log.debug(message.format(path=path))
+        makedirs(os.path.dirname(path))
+        with open(path, "w") as fh:
+            json.dump(contents, fh, indent=2, sort_keys=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,6 +19,7 @@ SCHEMA = os.path.join(TEST_DATA_DIR, "basic_schema.json")
 BASIC_TASK = os.path.join(TEST_DATA_DIR, "basic_task.json")
 
 
+# constants helpers and fixtures {{{1
 @pytest.fixture(scope='function')
 def config(tmpdir_factory):
     temp_dir = tmpdir_factory.mktemp("work_dir", numbered=True)
@@ -50,36 +51,42 @@ def no_sleep(*args, **kwargs):
     return 0
 
 
-class TestClient(object):
-    def test_get_missing_task(self, config):
+# tests {{{1
+def test_get_missing_task(config):
+    with pytest.raises(ScriptWorkerTaskException):
+        client.get_task(config)
+
+
+def test_get_task(config):
+    copyfile(BASIC_TASK, os.path.join(config['work_dir'], "task.json"))
+    assert client.get_task(config)["this_is_a_task"] is True
+
+
+def test_retry_fail_creds(config):
+    populate_credentials(config, [CLIENT_CREDS, PARTIAL_CREDS, PARTIAL_CREDS])
+    with mock.patch.object(utils, "calculateSleepTime", new=no_sleep):
         with pytest.raises(ScriptWorkerTaskException):
-            client.get_task(config)
+            client.get_temp_creds_from_file(config)
 
-    def test_get_task(self, config):
-        copyfile(BASIC_TASK, os.path.join(config['work_dir'], "task.json"))
-        assert client.get_task(config)["this_is_a_task"] is True
 
-    def test_retry_fail_creds(self, config):
-        populate_credentials(config, [CLIENT_CREDS, PARTIAL_CREDS, PARTIAL_CREDS])
-        with mock.patch.object(utils, "calculateSleepTime", new=no_sleep):
-            with pytest.raises(ScriptWorkerTaskException):
-                client.get_temp_creds_from_file(config)
+def test_get_missing_creds(config, event_loop):
+    with pytest.raises(ScriptWorkerTaskException):
+        event_loop.run_until_complete(client._get_temp_creds_from_file(config))
 
-    def test_get_missing_creds(self, config, event_loop):
-        with pytest.raises(ScriptWorkerTaskException):
-            event_loop.run_until_complete(client._get_temp_creds_from_file(config))
 
-    def test_validate_task(self, schema):
-        with open(BASIC_TASK, "r") as fh:
-            task = json.load(fh)
-        client.validate_task_schema(task, schema)
+def test_validate_task(schema):
+    with open(BASIC_TASK, "r") as fh:
+        task = json.load(fh)
+    client.validate_task_schema(task, schema)
 
-    def test_invalid_task(self, schema):
-        with open(BASIC_TASK, "r") as fh:
-            task = json.load(fh)
-        with pytest.raises(ScriptWorkerTaskException):
-            client.validate_task_schema({'foo': task}, schema)
 
-    def test_payload(self, config):
-        payload = client.integration_create_task_payload(config, 'a1234')
-        assert payload['scopes'] == []
+def test_invalid_task(schema):
+    with open(BASIC_TASK, "r") as fh:
+        task = json.load(fh)
+    with pytest.raises(ScriptWorkerTaskException):
+        client.validate_task_schema({'foo': task}, schema)
+
+
+def test_payload(config):
+    payload = client.integration_create_task_payload(config, 'a1234')
+    assert payload['scopes'] == []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ import pytest
 import scriptworker.config as config
 
 
+# constants helpers and fixtures {{{1
 ENV_CREDS_PARAMS = ((
     {
         'TASKCLUSTER_ACCESS_TOKEN': 'x',
@@ -37,75 +38,85 @@ def test_config():
     return deepcopy(config.DEFAULT_CONFIG)
 
 
-class TestConfig(object):
-    def test_nontext_to_unicode(self):
-        d = {'a': [1, 2, 3]}
-        config.list_to_tuple(d)
-        assert d == {'a': (1, 2, 3)}
+# tests {{{1
+def test_nontext_to_unicode():
+    d = {'a': [1, 2, 3]}
+    config.list_to_tuple(d)
+    assert d == {'a': (1, 2, 3)}
 
-    def test_check_config_invalid_key(self, test_config):
-        test_config['invalid_key_for_testing'] = 1
-        messages = config.check_config(test_config, "test_path")
-        assert "Unknown key" in "\n".join(messages)
 
-    def test_check_config_invalid_type(self, test_config):
-        test_config['log_dir'] = tuple(test_config['log_dir'])
-        messages = config.check_config(test_config, "test_path")
-        assert "log_dir: type" in "\n".join(messages)
+def test_check_config_invalid_key(test_config):
+    test_config['invalid_key_for_testing'] = 1
+    messages = config.check_config(test_config, "test_path")
+    assert "Unknown key" in "\n".join(messages)
 
-    def test_check_config_good(self, test_config):
-        for key, value in test_config.items():
-            if value == "...":
-                test_config[key] = "filled_in"
-        messages = config.check_config(test_config, "test_path")
-        assert messages == []
 
-    def test_create_config_missing_file(self):
-        with pytest.raises(SystemExit):
-            config.create_config("this_file_does_not_exist.json")
+def test_check_config_invalid_type(test_config):
+    test_config['log_dir'] = tuple(test_config['log_dir'])
+    messages = config.check_config(test_config, "test_path")
+    assert "log_dir: type" in "\n".join(messages)
 
-    def test_create_config_bad_config(self):
-        path = os.path.join(os.path.dirname(__file__), "data", "bad.json")
-        with pytest.raises(SystemExit):
-            config.create_config(path)
 
-    def test_create_config_good(self, test_config):
-        path = os.path.join(os.path.dirname(__file__), "data", "good.json")
-        with open(path, "r") as fh:
-            contents = json.load(fh)
-        test_config.update(contents)
-        test_creds = test_config['credentials']
-        del(test_config['credentials'])
-        generated_config, generated_creds = config.create_config(path)
-        assert generated_config == test_config
-        assert generated_creds == test_creds
-        assert isinstance(generated_config, frozendict)
-        assert isinstance(generated_creds, frozendict)
+def test_check_config_good(test_config):
+    for key, value in test_config.items():
+        if value == "...":
+            test_config[key] = "filled_in"
+    messages = config.check_config(test_config, "test_path")
+    assert messages == []
 
-    def test_bad_worker_creds(self):
-        path = os.path.join(os.path.dirname(__file__), "data", "good.json")
-        with mock.patch.object(config, 'CREDS_FILES', new=(path, )):
-            assert config.read_worker_creds(key="nonexistent_key") is None
 
-    def test_no_creds_in_config(self):
-        fake_creds = {"foo": "bar"}
+def test_create_config_missing_file():
+    with pytest.raises(SystemExit):
+        config.create_config("this_file_does_not_exist.json")
 
-        def fake_read(*args, **kwargs):
-            return deepcopy(fake_creds)
 
-        path = os.path.join(os.path.dirname(__file__), "data", "no_creds.json")
-        with mock.patch.object(config, 'read_worker_creds', new=fake_read):
-            _, creds = config.create_config(path=path)
-        assert creds == fake_creds
+def test_create_config_bad_config():
+    path = os.path.join(os.path.dirname(__file__), "data", "bad.json")
+    with pytest.raises(SystemExit):
+        config.create_config(path)
 
-    def test_missing_creds(self):
-        with mock.patch.object(config, 'CREDS_FILES', new=['this_file_does_not_exist']):
-            assert config.read_worker_creds() is None
 
-    @pytest.mark.parametrize("params", ENV_CREDS_PARAMS)
-    def test_environ_creds(self, params):
-        env = deepcopy(os.environ)
-        env.update(params[0])
-        with mock.patch.object(config, 'CREDS_FILES', new=['this_file_does_not_exist']):
-            with mock.patch.object(os, 'environ', new=env):
-                assert config.read_worker_creds() == params[1]
+def test_create_config_good(test_config):
+    path = os.path.join(os.path.dirname(__file__), "data", "good.json")
+    with open(path, "r") as fh:
+        contents = json.load(fh)
+    test_config.update(contents)
+    test_creds = test_config['credentials']
+    del(test_config['credentials'])
+    generated_config, generated_creds = config.create_config(path)
+    assert generated_config == test_config
+    assert generated_creds == test_creds
+    assert isinstance(generated_config, frozendict)
+    assert isinstance(generated_creds, frozendict)
+
+
+def test_bad_worker_creds():
+    path = os.path.join(os.path.dirname(__file__), "data", "good.json")
+    with mock.patch.object(config, 'CREDS_FILES', new=(path, )):
+        assert config.read_worker_creds(key="nonexistent_key") is None
+
+
+def test_no_creds_in_config():
+    fake_creds = {"foo": "bar"}
+
+    def fake_read(*args, **kwargs):
+        return deepcopy(fake_creds)
+
+    path = os.path.join(os.path.dirname(__file__), "data", "no_creds.json")
+    with mock.patch.object(config, 'read_worker_creds', new=fake_read):
+        _, creds = config.create_config(path=path)
+    assert creds == fake_creds
+
+
+def test_missing_creds():
+    with mock.patch.object(config, 'CREDS_FILES', new=['this_file_does_not_exist']):
+        assert config.read_worker_creds() is None
+
+
+@pytest.mark.parametrize("params", ENV_CREDS_PARAMS)
+def test_environ_creds(params):
+    env = deepcopy(os.environ)
+    env.update(params[0])
+    with mock.patch.object(config, 'CREDS_FILES', new=['this_file_does_not_exist']):
+        with mock.patch.object(os, 'environ', new=env):
+            assert config.read_worker_creds() == params[1]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -8,6 +8,7 @@ import pytest
 from scriptworker.context import Context
 
 
+# constants helpers and fixtures {{{1
 @pytest.fixture(scope='function')
 def context(tmpdir_factory):
     temp_dir = tmpdir_factory.mktemp("context", numbered=True)
@@ -51,42 +52,46 @@ def get_json(path):
         return json.load(fh)
 
 
-class TestContext(object):
-    def test_empty_context(self, context):
-        assert context.task is None
-        assert context.claim_task is None
-        assert context.reclaim_task is None
-        assert context.temp_credentials is None
+# tests {{{1
+def test_empty_context(context):
+    assert context.task is None
+    assert context.claim_task is None
+    assert context.reclaim_task is None
+    assert context.temp_credentials is None
 
-    def test_set_task(self, context, claim_task):
-        context.claim_task = claim_task
-        assert context.claim_task == claim_task
-        assert context.reclaim_task is None
-        assert context.temp_credentials == claim_task['credentials']
-        assert get_json(get_task_file(context)) == claim_task['task']
 
-    def test_set_reclaim_task(self, context, claim_task, reclaim_task):
-        context.claim_task = claim_task
-        context.reclaim_task = reclaim_task
-        assert context.claim_task == claim_task
-        assert context.task == claim_task['task']
-        assert context.reclaim_task == reclaim_task
-        assert context.temp_credentials == reclaim_task['credentials']
-        assert get_json(get_task_file(context)) == claim_task['task']
+def test_set_task(context, claim_task):
+    context.claim_task = claim_task
+    assert context.claim_task == claim_task
+    assert context.reclaim_task is None
+    assert context.temp_credentials == claim_task['credentials']
+    assert get_json(get_task_file(context)) == claim_task['task']
 
-    def test_set_reset_task(self, context, claim_task, reclaim_task):
-        context.claim_task = claim_task
-        context.reclaim_task = reclaim_task
-        context.claim_task = None
-        assert context.claim_task is None
-        assert context.task is None
-        assert context.reclaim_task is None
-        assert context.proc is None
-        assert context.temp_credentials is None
-        assert context.temp_queue is None
 
-    def test_reset_credentials(self, context, claim_task):
-        context.claim_task = claim_task
-        context.credentials = None
-        assert context.credentials is None
-        assert context.queue is None
+def test_set_reclaim_task(context, claim_task, reclaim_task):
+    context.claim_task = claim_task
+    context.reclaim_task = reclaim_task
+    assert context.claim_task == claim_task
+    assert context.task == claim_task['task']
+    assert context.reclaim_task == reclaim_task
+    assert context.temp_credentials == reclaim_task['credentials']
+    assert get_json(get_task_file(context)) == claim_task['task']
+
+
+def test_set_reset_task(context, claim_task, reclaim_task):
+    context.claim_task = claim_task
+    context.reclaim_task = reclaim_task
+    context.claim_task = None
+    assert context.claim_task is None
+    assert context.task is None
+    assert context.reclaim_task is None
+    assert context.proc is None
+    assert context.temp_credentials is None
+    assert context.temp_queue is None
+
+
+def test_reset_credentials(context, claim_task):
+    context.claim_task = claim_task
+    context.credentials = None
+    assert context.credentials is None
+    assert context.queue is None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,6 +18,7 @@ import scriptworker.log as swlog
 import scriptworker.worker as worker
 import scriptworker.utils as utils
 
+# constants helpers and fixtures {{{1
 TIMEOUT_SCRIPT = os.path.join(os.path.dirname(__file__), "data", "long_running.py")
 SKIP_REASON = "NO_TESTS_OVER_WIRE: skipping integration test"
 
@@ -129,67 +130,70 @@ def remember_cwd():
         os.chdir(curdir)
 
 
-class TestIntegration(object):
-    @pytest.mark.skipif(os.environ.get("NO_TESTS_OVER_WIRE"), reason=SKIP_REASON)
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("context_function", [get_context, get_temp_creds_context])
-    async def test_run_successful_task(self, event_loop, context_function):
-        task_id = slugid.nice().decode('utf-8')
-        task_group_id = slugid.nice().decode('utf-8')
-        with context_function(None) as context:
-            result = await create_task(context, task_id, task_group_id)
-            assert result['status']['state'] == 'pending'
-            with remember_cwd():
-                os.chdir("integration")
-                status = await worker.run_loop(context, creds_key="integration_credentials")
-            assert status == 1
-            result = await task_status(context, task_id)
-            assert result['status']['state'] == 'failed'
+# tests {{{1
+@pytest.mark.skipif(os.environ.get("NO_TESTS_OVER_WIRE"), reason=SKIP_REASON)
+@pytest.mark.asyncio
+@pytest.mark.parametrize("context_function", [get_context, get_temp_creds_context])
+async def test_run_successful_task(event_loop, context_function):
+    task_id = slugid.nice().decode('utf-8')
+    task_group_id = slugid.nice().decode('utf-8')
+    with context_function(None) as context:
+        result = await create_task(context, task_id, task_group_id)
+        assert result['status']['state'] == 'pending'
+        with remember_cwd():
+            os.chdir("integration")
+            status = await worker.run_loop(context, creds_key="integration_credentials")
+        assert status == 1
+        result = await task_status(context, task_id)
+        assert result['status']['state'] == 'failed'
 
-    @pytest.mark.skipif(os.environ.get("NO_TESTS_OVER_WIRE"), reason=SKIP_REASON)
-    @pytest.mark.parametrize("context_function", [get_context, get_temp_creds_context])
-    def test_run_maxtimeout(self, event_loop, context_function):
-        task_id = slugid.nice().decode('utf-8')
-        task_group_id = slugid.nice().decode('utf-8')
-        partial_config = {
-            'task_max_timeout': 2,
-        }
-        with context_function(partial_config) as context:
-            result = event_loop.run_until_complete(
-                create_task(context, task_id, task_group_id)
-            )
-            assert result['status']['state'] == 'pending'
-            with remember_cwd():
-                os.chdir("integration")
-                with pytest.raises(RuntimeError):
-                    event_loop.run_until_complete(
-                        worker.run_loop(context, creds_key="integration_credentials")
-                    )
-                    # Because we're using asyncio to kill tasks in the loop,
-                    # we're going to hit a RuntimeError
-            result = event_loop.run_until_complete(task_status(context, task_id))
-            # TODO We need to be able to ensure this is 'failed'.
-            assert result['status']['state'] in ('failed', 'running')
 
-    @pytest.mark.skipif(os.environ.get("NO_TESTS_OVER_WIRE"), reason=SKIP_REASON)
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("context_function", [get_context, get_temp_creds_context])
-    async def test_empty_queue(self, event_loop, context_function):
-        with context_function(None) as context:
-            with remember_cwd():
-                os.chdir("integration")
-                status = await worker.run_loop(context, creds_key="integration_credentials")
-            assert status is None
-
-    @pytest.mark.skipif(os.environ.get("NO_TESTS_OVER_WIRE"), reason=SKIP_REASON)
-    @pytest.mark.parametrize("context_function", [get_context, get_temp_creds_context])
-    def test_temp_creds(self, event_loop, context_function):
-        with context_function(None) as context:
-            with remember_cwd():
-                os.chdir("integration")
-                context.temp_credentials = utils.create_temp_creds(
-                    context.credentials['clientId'], context.credentials['accessToken'],
-                    expires=arrow.utcnow().replace(minutes=10).datetime
+@pytest.mark.skipif(os.environ.get("NO_TESTS_OVER_WIRE"), reason=SKIP_REASON)
+@pytest.mark.parametrize("context_function", [get_context, get_temp_creds_context])
+def test_run_maxtimeout(event_loop, context_function):
+    task_id = slugid.nice().decode('utf-8')
+    task_group_id = slugid.nice().decode('utf-8')
+    partial_config = {
+        'task_max_timeout': 2,
+    }
+    with context_function(partial_config) as context:
+        result = event_loop.run_until_complete(
+            create_task(context, task_id, task_group_id)
+        )
+        assert result['status']['state'] == 'pending'
+        with remember_cwd():
+            os.chdir("integration")
+            with pytest.raises(RuntimeError):
+                event_loop.run_until_complete(
+                    worker.run_loop(context, creds_key="integration_credentials")
                 )
-                result = event_loop.run_until_complete(context.temp_queue.ping())
-                assert result['alive']
+                # Because we're using asyncio to kill tasks in the loop,
+                # we're going to hit a RuntimeError
+        result = event_loop.run_until_complete(task_status(context, task_id))
+        # TODO We need to be able to ensure this is 'failed'.
+        assert result['status']['state'] in ('failed', 'running')
+
+
+@pytest.mark.skipif(os.environ.get("NO_TESTS_OVER_WIRE"), reason=SKIP_REASON)
+@pytest.mark.asyncio
+@pytest.mark.parametrize("context_function", [get_context, get_temp_creds_context])
+async def test_empty_queue(event_loop, context_function):
+    with context_function(None) as context:
+        with remember_cwd():
+            os.chdir("integration")
+            status = await worker.run_loop(context, creds_key="integration_credentials")
+        assert status is None
+
+
+@pytest.mark.skipif(os.environ.get("NO_TESTS_OVER_WIRE"), reason=SKIP_REASON)
+@pytest.mark.parametrize("context_function", [get_context, get_temp_creds_context])
+def test_temp_creds(event_loop, context_function):
+    with context_function(None) as context:
+        with remember_cwd():
+            os.chdir("integration")
+            context.temp_credentials = utils.create_temp_creds(
+                context.credentials['clientId'], context.credentials['accessToken'],
+                expires=arrow.utcnow().replace(minutes=10).datetime
+            )
+            result = event_loop.run_until_complete(context.temp_queue.ping())
+            assert result['alive']

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -12,6 +12,7 @@ import scriptworker.log as swlog
 from . import read
 
 
+# constants helpers and fixtures {{{1
 @pytest.fixture(scope='function')
 def context(tmpdir_factory):
     temp_dir = tmpdir_factory.mktemp("context", numbered=True)
@@ -36,47 +37,51 @@ of text
 """
 
 
-class TestLog(object):
-    def test_get_log_filenames(self, context):
-        log_file, error_file = swlog.get_log_filenames(context)
-        assert log_file == os.path.join(context.config['log_dir'], 'task_output.log')
-        assert error_file == os.path.join(context.config['log_dir'], 'task_error.log')
+# tests {{{1
+def test_get_log_filenames(context):
+    log_file, error_file = swlog.get_log_filenames(context)
+    assert log_file == os.path.join(context.config['log_dir'], 'task_output.log')
+    assert error_file == os.path.join(context.config['log_dir'], 'task_error.log')
 
-    def test_get_log_fhs(self, context, text):
-        log_file, error_file = swlog.get_log_filenames(context)
-        with swlog.get_log_fhs(context) as (log_fh, error_fh):
-            print(text, file=log_fh, end="")
-            print(text, file=error_fh, end="")
-            print(text, file=error_fh, end="")
-        assert read(log_file) == text
-        assert read(error_file) == text + text
 
-    @pytest.mark.asyncio
-    async def test_read_stdout(self, context):
-        cmd = r""">&2 echo "foo" && echo "bar" && exit 0"""
-        proc = await asyncio.create_subprocess_exec(
-            "bash", "-c", cmd,
-            stdout=PIPE, stderr=PIPE, stdin=None
-        )
-        tasks = []
-        with swlog.get_log_fhs(context) as (log_fh, error_fh):
-            tasks.append(swlog.log_errors(proc.stderr, log_fh, error_fh))
-            tasks.append(swlog.read_stdout(proc.stdout, log_fh))
-            await asyncio.wait(tasks)
-            await proc.wait()
-        log_file, error_file = swlog.get_log_filenames(context)
-        assert read(log_file) in ("foo\nbar\n", "bar\nfoo\n")
-        assert read(error_file) == "foo\n"
+def test_get_log_fhs(context, text):
+    log_file, error_file = swlog.get_log_filenames(context)
+    with swlog.get_log_fhs(context) as (log_fh, error_fh):
+        print(text, file=log_fh, end="")
+        print(text, file=error_fh, end="")
+        print(text, file=error_fh, end="")
+    assert read(log_file) == text
+    assert read(error_file) == text + text
 
-    def test_update_logging_config_verbose(self, context):
-        swlog.update_logging_config(context, context.config['log_dir'])
-        log = logging.getLogger(context.config['log_dir'])
-        assert log.level == logging.DEBUG
-        assert len(log.handlers) == 3
 
-    def test_update_logging_config_not_verbose(self, context):
-        context.config['verbose'] = False
-        swlog.update_logging_config(context, context.config['log_dir'])
-        log = logging.getLogger(context.config['log_dir'])
-        assert log.level == logging.INFO
-        assert len(log.handlers) == 2
+@pytest.mark.asyncio
+async def test_read_stdout(context):
+    cmd = r""">&2 echo "foo" && echo "bar" && exit 0"""
+    proc = await asyncio.create_subprocess_exec(
+        "bash", "-c", cmd,
+        stdout=PIPE, stderr=PIPE, stdin=None
+    )
+    tasks = []
+    with swlog.get_log_fhs(context) as (log_fh, error_fh):
+        tasks.append(swlog.log_errors(proc.stderr, log_fh, error_fh))
+        tasks.append(swlog.read_stdout(proc.stdout, log_fh))
+        await asyncio.wait(tasks)
+        await proc.wait()
+    log_file, error_file = swlog.get_log_filenames(context)
+    assert read(log_file) in ("foo\nbar\n", "bar\nfoo\n")
+    assert read(error_file) == "foo\n"
+
+
+def test_update_logging_config_verbose(context):
+    swlog.update_logging_config(context, context.config['log_dir'])
+    log = logging.getLogger(context.config['log_dir'])
+    assert log.level == logging.DEBUG
+    assert len(log.handlers) == 3
+
+
+def test_update_logging_config_not_verbose(context):
+    context.config['verbose'] = False
+    swlog.update_logging_config(context, context.config['log_dir'])
+    log = logging.getLogger(context.config['log_dir'])
+    assert log.level == logging.INFO
+    assert len(log.handlers) == 2

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -12,6 +12,7 @@ from . import successful_queue, unsuccessful_queue
 assert successful_queue, unsuccessful_queue  # silence flake8
 
 
+# constants helpers and fixtures {{{1
 @pytest.mark.asyncio
 async def fake_response(*args, **kwargs):
     return (args, kwargs)
@@ -49,71 +50,78 @@ def azure_xml():
     return xml
 
 
-class TestPoll(object):
-    def test_parse_azure_xml(self, azure_xml):
-        results = [{
-            "messageId": "fdfc7989-b048-4ea8-bd33-69f63b83ba54",
-            "popReceipt": "AgAAAAMAAAAAAAAAMApAvp2X0QE%3D",
-            "messageText": "eyJ0YXNrSWQiOiJHVmkydlR3OFJZcWRnYTZwRTA4QWl3IiwicnVuSWQiOjB9",
-            "task_info": {
-                "runId": 0,
-                "taskId": "GVi2vTw8RYqdga6pE08Aiw",
-            },
-        }, {
-            "messageId": "two_id",
-            "popReceipt": "two_pop%3D",
-            "messageText": "eyJydW5JZCI6IDAsICJ0YXNrSWQiOiAiYXNkZiJ9Cg==",
-            "task_info": {
-                "runId": 0,
-                "taskId": 'asdf',
-            },
-        }]
-        count = -1
-        for message in poll.parse_azure_xml(azure_xml):
-            count += 1
-            assert message == results[count]
+# tests {{{1
+def test_parse_azure_xml(azure_xml):
+    results = [{
+        "messageId": "fdfc7989-b048-4ea8-bd33-69f63b83ba54",
+        "popReceipt": "AgAAAAMAAAAAAAAAMApAvp2X0QE%3D",
+        "messageText": "eyJ0YXNrSWQiOiJHVmkydlR3OFJZcWRnYTZwRTA4QWl3IiwicnVuSWQiOjB9",
+        "task_info": {
+            "runId": 0,
+            "taskId": "GVi2vTw8RYqdga6pE08Aiw",
+        },
+    }, {
+        "messageId": "two_id",
+        "popReceipt": "two_pop%3D",
+        "messageText": "eyJydW5JZCI6IDAsICJ0YXNrSWQiOiAiYXNkZiJ9Cg==",
+        "task_info": {
+            "runId": 0,
+            "taskId": 'asdf',
+        },
+    }]
+    count = -1
+    for message in poll.parse_azure_xml(azure_xml):
+        count += 1
+        assert message == results[count]
 
-    @pytest.mark.asyncio
-    async def test_successful_claim_task(self, context, successful_queue):
-        context.queue = successful_queue
-        result = await poll.claim_task(context, 1, 2)
-        assert result == successful_queue.result
 
-    @pytest.mark.asyncio
-    async def test_unsuccessful_claim_task(self, context, unsuccessful_queue):
-        context.queue = unsuccessful_queue
-        result = await poll.claim_task(context, 1, 2)
-        assert result is None
+@pytest.mark.asyncio
+async def test_successful_claim_task(context, successful_queue):
+    context.queue = successful_queue
+    result = await poll.claim_task(context, 1, 2)
+    assert result == successful_queue.result
 
-    @pytest.mark.asyncio
-    async def test_update_expired_poll_task_urls(self, context):
-        context.poll_task_urls['expires'] = "2016-04-16T03:46:24.958Z"
-        await poll.update_poll_task_urls(context, fake_response)
-        assert context.poll_task_urls == ((), {})
 
-    @pytest.mark.asyncio
-    async def test_update_unexpired_poll_task_urls(self, context):
-        expires = arrow.utcnow().replace(hours=10)
-        context.poll_task_urls['expires'] = expires.isoformat()
-        good = deepcopy(context.poll_task_urls)
-        await poll.update_poll_task_urls(context, fake_response)
-        assert context.poll_task_urls == good
+@pytest.mark.asyncio
+async def test_unsuccessful_claim_task(context, unsuccessful_queue):
+    context.queue = unsuccessful_queue
+    result = await poll.claim_task(context, 1, 2)
+    assert result is None
 
-    def test_get_azure_urls(self, context):
-        count = 0
-        for poll_url, delete_url in poll.get_azure_urls(context):
-            assert poll_url == "poll{}".format(count)
-            assert delete_url == "delete{}".format(count)
-            count += 1
 
-    @pytest.mark.asyncio
-    async def test_successful_find_task(self, context, successful_queue):
-        context.queue = successful_queue
-        result = await poll.find_task(context, "poll", "delete", fake_request)
-        assert result == "yay"
+@pytest.mark.asyncio
+async def test_update_expired_poll_task_urls(context):
+    context.poll_task_urls['expires'] = "2016-04-16T03:46:24.958Z"
+    await poll.update_poll_task_urls(context, fake_response)
+    assert context.poll_task_urls == ((), {})
 
-    @pytest.mark.asyncio
-    async def test_unsuccessful_find_task(self, context, unsuccessful_queue):
-        context.queue = unsuccessful_queue
-        result = await poll.find_task(context, "poll", "delete", fake_request)
-        assert result is None
+
+@pytest.mark.asyncio
+async def test_update_unexpired_poll_task_urls(context):
+    expires = arrow.utcnow().replace(hours=10)
+    context.poll_task_urls['expires'] = expires.isoformat()
+    good = deepcopy(context.poll_task_urls)
+    await poll.update_poll_task_urls(context, fake_response)
+    assert context.poll_task_urls == good
+
+
+def test_get_azure_urls(context):
+    count = 0
+    for poll_url, delete_url in poll.get_azure_urls(context):
+        assert poll_url == "poll{}".format(count)
+        assert delete_url == "delete{}".format(count)
+        count += 1
+
+
+@pytest.mark.asyncio
+async def test_successful_find_task(context, successful_queue):
+    context.queue = successful_queue
+    result = await poll.find_task(context, "poll", "delete", fake_request)
+    assert result == "yay"
+
+
+@pytest.mark.asyncio
+async def test_unsuccessful_find_task(context, unsuccessful_queue):
+    context.queue = unsuccessful_queue
+    result = await poll.find_task(context, "poll", "delete", fake_request)
+    assert result is None

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -21,6 +21,7 @@ from . import fake_session, fake_session_500, successful_queue, unsuccessful_que
 assert fake_session, fake_session_500  # silence flake8
 assert successful_queue, unsuccessful_queue  # silence flake8
 
+# constants helpers and fixtures {{{1
 TIMEOUT_SCRIPT = os.path.join(os.path.dirname(__file__), "data", "long_running.py")
 
 
@@ -58,161 +59,176 @@ mimetypes = {
 }
 
 
-class TestTask(object):
-    def test_temp_queue(self, context, mocker):
-        context.temp_credentials = {'a': 'b'}
-        context.session = {'c': 'd'}
-        mocker.patch('taskcluster.async.Queue')
-        task.get_temp_queue(context)
-        assert taskcluster.async.Queue.called_once_with({
-            'credentials': context.temp_credentials,
-        }, session=context.session)
+# tests {{{1
+def test_temp_queue(context, mocker):
+    context.temp_credentials = {'a': 'b'}
+    context.session = {'c': 'd'}
+    mocker.patch('taskcluster.async.Queue')
+    task.get_temp_queue(context)
+    assert taskcluster.async.Queue.called_once_with({
+        'credentials': context.temp_credentials,
+    }, session=context.session)
 
-    def test_expiration_arrow(self, context):
-        now = arrow.utcnow()
 
-        # make sure time differences don't screw up the test
-        with mock.patch.object(arrow, 'utcnow') as p:
-            p.return_value = now
-            expiration = task.get_expiration_arrow(context)
-            diff = expiration.timestamp - now.timestamp
-            assert diff == 3600
+def test_expiration_arrow(context):
+    now = arrow.utcnow()
 
-    @pytest.mark.parametrize("mimetypes", [(k, v) for k, v in sorted(mimetypes.items())])
-    def test_guess_content_type(self, mimetypes):
-        path, mimetype = mimetypes
-        assert task.guess_content_type(path) == mimetype
+    # make sure time differences don't screw up the test
+    with mock.patch.object(arrow, 'utcnow') as p:
+        p.return_value = now
+        expiration = task.get_expiration_arrow(context)
+        diff = expiration.timestamp - now.timestamp
+        assert diff == 3600
 
-    @pytest.mark.asyncio
-    async def test_run_task(self, context):
-        status = await task.run_task(context)
-        log_file, error_file = log.get_log_filenames(context)
-        assert read(log_file) in ("bar\nfoo\nexit code: 1\n", "foo\nbar\nexit code: 1\n")
-        assert read(error_file) == "bar\n"
-        assert status == 1
 
-    @pytest.mark.asyncio
-    async def test_reportCompleted(self, context, successful_queue):
-        with mock.patch('scriptworker.task.get_temp_queue') as p:
-            p.return_value = successful_queue
-            await task.complete_task(context, 0)
-        assert successful_queue.info == ["reportCompleted", ('taskId', 'runId'), {}]
+@pytest.mark.parametrize("mimetypes", [(k, v) for k, v in sorted(mimetypes.items())])
+def test_guess_content_type(mimetypes):
+    path, mimetype = mimetypes
+    assert task.guess_content_type(path) == mimetype
 
-    @pytest.mark.asyncio
-    async def test_reportFailed(self, context, successful_queue):
-        with mock.patch('scriptworker.task.get_temp_queue') as p:
-            p.return_value = successful_queue
-            await task.complete_task(context, 1)
-        assert successful_queue.info == ["reportFailed", ('taskId', 'runId'), {}]
 
-    @pytest.mark.asyncio
-    async def test_reportException(self, context, successful_queue):
-        with mock.patch('scriptworker.task.get_temp_queue') as p:
-            p.return_value = successful_queue
-            await task.complete_task(context, 2)
-        assert successful_queue.info == ["reportException", ('taskId', 'runId', {'reason': 'worker-shutdown'}), {}]
+@pytest.mark.asyncio
+async def test_run_task(context):
+    status = await task.run_task(context)
+    log_file, error_file = log.get_log_filenames(context)
+    assert read(log_file) in ("bar\nfoo\nexit code: 1\n", "foo\nbar\nexit code: 1\n")
+    assert read(error_file) == "bar\n"
+    assert status == 1
 
-    @pytest.mark.asyncio
-    async def test_complete_task_409(self, context, unsuccessful_queue):
+
+@pytest.mark.asyncio
+async def test_reportCompleted(context, successful_queue):
+    with mock.patch('scriptworker.task.get_temp_queue') as p:
+        p.return_value = successful_queue
+        await task.complete_task(context, 0)
+    assert successful_queue.info == ["reportCompleted", ('taskId', 'runId'), {}]
+
+
+@pytest.mark.asyncio
+async def test_reportFailed(context, successful_queue):
+    with mock.patch('scriptworker.task.get_temp_queue') as p:
+        p.return_value = successful_queue
+        await task.complete_task(context, 1)
+    assert successful_queue.info == ["reportFailed", ('taskId', 'runId'), {}]
+
+
+@pytest.mark.asyncio
+async def test_reportException(context, successful_queue):
+    with mock.patch('scriptworker.task.get_temp_queue') as p:
+        p.return_value = successful_queue
+        await task.complete_task(context, 2)
+    assert successful_queue.info == ["reportException", ('taskId', 'runId', {'reason': 'worker-shutdown'}), {}]
+
+
+@pytest.mark.asyncio
+async def test_complete_task_409(context, unsuccessful_queue):
+    with mock.patch('scriptworker.task.get_temp_queue') as p:
+        p.return_value = unsuccessful_queue
+        await task.complete_task(context, 0)
+
+
+@pytest.mark.asyncio
+async def test_complete_task_non_409(context, unsuccessful_queue):
+    unsuccessful_queue.status = 500
+    with pytest.raises(taskcluster.exceptions.TaskclusterRestFailure):
         with mock.patch('scriptworker.task.get_temp_queue') as p:
             p.return_value = unsuccessful_queue
             await task.complete_task(context, 0)
 
-    @pytest.mark.asyncio
-    async def test_complete_task_non_409(self, context, unsuccessful_queue):
-        unsuccessful_queue.status = 500
-        with pytest.raises(taskcluster.exceptions.TaskclusterRestFailure):
-            with mock.patch('scriptworker.task.get_temp_queue') as p:
-                p.return_value = unsuccessful_queue
-                await task.complete_task(context, 0)
 
-    @pytest.mark.asyncio
-    async def test_reclaim_task(self, context, successful_queue):
+@pytest.mark.asyncio
+async def test_reclaim_task(context, successful_queue):
+    with mock.patch('scriptworker.task.get_temp_queue') as p:
+        p.return_value = successful_queue
+        await task.reclaim_task(context)
+
+
+@pytest.mark.asyncio
+async def test_reclaim_task_non_409(context, successful_queue):
+    successful_queue.status = 500
+    with pytest.raises(taskcluster.exceptions.TaskclusterRestFailure):
         with mock.patch('scriptworker.task.get_temp_queue') as p:
             p.return_value = successful_queue
             await task.reclaim_task(context)
 
-    @pytest.mark.asyncio
-    async def test_reclaim_task_non_409(self, context, successful_queue):
-        successful_queue.status = 500
-        with pytest.raises(taskcluster.exceptions.TaskclusterRestFailure):
-            with mock.patch('scriptworker.task.get_temp_queue') as p:
-                p.return_value = successful_queue
-                await task.reclaim_task(context)
 
-    @pytest.mark.asyncio
-    async def test_upload_artifacts(self, context):
-        args = []
-        os.makedirs(context.config['artifact_dir'])
-        os.makedirs(context.config['log_dir'])
-        paths = list(log.get_log_filenames(context)) + [
-            os.path.join(context.config['artifact_dir'], 'one'),
-            os.path.join(context.config['artifact_dir'], 'two'),
-        ]
-        for path in paths:
-            touch(path)
-
-        async def foo(_, path, **kwargs):
-            args.append(path)
-
-        with mock.patch('scriptworker.task.create_artifact', new=foo):
-            await task.upload_artifacts(context)
-
-        assert sorted(args) == sorted(paths)
-
-    @pytest.mark.asyncio
-    async def test_create_artifact(self, context, fake_session, successful_queue):
-        path = os.path.join(context.config['artifact_dir'], "one.txt")
-        os.makedirs(context.config['artifact_dir'])
+@pytest.mark.asyncio
+async def test_upload_artifacts(context):
+    args = []
+    os.makedirs(context.config['artifact_dir'])
+    os.makedirs(context.config['log_dir'])
+    paths = list(log.get_log_filenames(context)) + [
+        os.path.join(context.config['artifact_dir'], 'one'),
+        os.path.join(context.config['artifact_dir'], 'two'),
+    ]
+    for path in paths:
         touch(path)
-        context.session = fake_session
-        expires = arrow.utcnow().isoformat()
+
+    async def foo(_, path, **kwargs):
+        args.append(path)
+
+    with mock.patch('scriptworker.task.create_artifact', new=foo):
+        await task.upload_artifacts(context)
+
+    assert sorted(args) == sorted(paths)
+
+
+@pytest.mark.asyncio
+async def test_create_artifact(context, fake_session, successful_queue):
+    path = os.path.join(context.config['artifact_dir'], "one.txt")
+    os.makedirs(context.config['artifact_dir'])
+    touch(path)
+    context.session = fake_session
+    expires = arrow.utcnow().isoformat()
+    with mock.patch('scriptworker.task.get_temp_queue') as p:
+        p.return_value = successful_queue
+        await task.create_artifact(context, path, expires=expires)
+    assert successful_queue.info == [
+        "createArtifact", ('taskId', 'runId', "public/env/one.txt", {
+            "storageType": "s3",
+            "expires": expires,
+            "contentType": "text/plain",
+        }), {}
+    ]
+    context.session.close()
+
+
+@pytest.mark.asyncio
+async def test_create_artifact_retry(context, fake_session_500, successful_queue):
+    path = os.path.join(context.config['artifact_dir'], "one.log")
+    os.makedirs(context.config['artifact_dir'])
+    touch(path)
+    context.session = fake_session_500
+    expires = arrow.utcnow().isoformat()
+    with pytest.raises(ScriptWorkerRetryException):
         with mock.patch('scriptworker.task.get_temp_queue') as p:
             p.return_value = successful_queue
             await task.create_artifact(context, path, expires=expires)
-        assert successful_queue.info == [
-            "createArtifact", ('taskId', 'runId', "public/env/one.txt", {
-                "storageType": "s3",
-                "expires": expires,
-                "contentType": "text/plain",
-            }), {}
-        ]
-        context.session.close()
+    context.session.close()
 
-    @pytest.mark.asyncio
-    async def test_create_artifact_retry(self, context, fake_session_500, successful_queue):
-        path = os.path.join(context.config['artifact_dir'], "one.log")
-        os.makedirs(context.config['artifact_dir'])
-        touch(path)
-        context.session = fake_session_500
-        expires = arrow.utcnow().isoformat()
-        with pytest.raises(ScriptWorkerRetryException):
-            with mock.patch('scriptworker.task.get_temp_queue') as p:
-                p.return_value = successful_queue
-                await task.create_artifact(context, path, expires=expires)
-        context.session.close()
 
-    def test_max_timeout_noop(self, context):
-        with mock.patch.object(task.log, 'debug') as p:
-            task.max_timeout(context, "invalid_proc", 0)
-            assert not p.called
+def test_max_timeout_noop(context):
+    with mock.patch.object(task.log, 'debug') as p:
+        task.max_timeout(context, "invalid_proc", 0)
+        assert not p.called
 
-    def test_max_timeout(self, context, event_loop):
-        temp_dir = os.path.join(context.config['work_dir'], "timeout")
-        context.config['task_script'] = (
-            sys.executable, TIMEOUT_SCRIPT, temp_dir
-        )
-        context.config['task_max_timeout'] = 3
-        event_loop.run_until_complete(task.run_task(context))
-        try:
-            event_loop.run_until_complete(asyncio.sleep(10))  # Let kill() calls run
-        except RuntimeError:
-            pass
-        files = {}
-        for path in glob.glob(os.path.join(temp_dir, '*')):
-            files[path] = (time.ctime(os.path.getmtime(path)), os.stat(path).st_size)
-            print("{} {}".format(path, files[path]))
-        for path in glob.glob(os.path.join(temp_dir, '*')):
-            print("Checking {}...".format(path))
-            assert files[path] == (time.ctime(os.path.getmtime(path)), os.stat(path).st_size)
-        assert len(files.keys()) == 6
+
+def test_max_timeout(context, event_loop):
+    temp_dir = os.path.join(context.config['work_dir'], "timeout")
+    context.config['task_script'] = (
+        sys.executable, TIMEOUT_SCRIPT, temp_dir
+    )
+    context.config['task_max_timeout'] = 3
+    event_loop.run_until_complete(task.run_task(context))
+    try:
+        event_loop.run_until_complete(asyncio.sleep(10))  # Let kill() calls run
+    except RuntimeError:
+        pass
+    files = {}
+    for path in glob.glob(os.path.join(temp_dir, '*')):
+        files[path] = (time.ctime(os.path.getmtime(path)), os.stat(path).st_size)
+        print("{} {}".format(path, files[path]))
+    for path in glob.glob(os.path.join(temp_dir, '*')):
+        print("Checking {}...".format(path))
+        assert files[path] == (time.ctime(os.path.getmtime(path)), os.stat(path).st_size)
+    assert len(files.keys()) == 6

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -8,6 +8,7 @@ import scriptworker.version as swversion
 import pytest
 import tempfile
 
+# constants helpers and fixtures {{{1
 LEGAL_VERSIONS = (
     ('0.1.0', (0, 1, 0)),
     ('1.2.3', (1, 2, 3)),
@@ -31,39 +32,41 @@ def fake_version_string():
     return "version string!!!"
 
 
-class TestVersionString(object):
-    """Test the various semver version->version string conversions
+# tests {{{1
+@pytest.mark.parametrize("version_tuple", LEGAL_VERSIONS)
+def test_legal_version(version_tuple):
+    """test_version | version tuple -> version string
     """
-    @pytest.mark.parametrize("version_tuple", LEGAL_VERSIONS)
-    def test_legal_version(self, version_tuple):
-        """test_version | version tuple -> version string
-        """
-        assert swversion.get_version_string(version_tuple[1]) == version_tuple[0]
+    assert swversion.get_version_string(version_tuple[1]) == version_tuple[0]
 
-    def test_illegal_three_version(self):
-        """test_version | Raise if a 3-len tuple has a non-digit
-        """
-        with pytest.raises(TypeError):
-            swversion.get_version_string(('one', 'two', 'three'))
 
-    def test_four_version(self):
-        """test_version | 3 digit + string tuple -> version string
-        """
-        assert swversion.get_version_string((0, 1, 0, 'alpha')) == '0.1.0-alpha'
+def test_illegal_three_version():
+    """test_version | Raise if a 3-len tuple has a non-digit
+    """
+    with pytest.raises(TypeError):
+        swversion.get_version_string(('one', 'two', 'three'))
 
-    @pytest.mark.parametrize("version_tuple", ILLEGAL_LENGTH_VERSIONS)
-    def test_illegal_len_version(self, version_tuple):
-        """test_version | Raise if len(version) not in (3, 4)
-        """
-        with pytest.raises(Exception):
-            swversion.get_version_string(version_tuple)
 
-    def test_write_version(self, mocker, fake_version_tuple, fake_version_string):
-        mocker.patch.object(swversion, '__version__', new=fake_version_tuple)
-        mocker.patch.object(swversion, '__version_string__', new=fake_version_string)
-        _, path = tempfile.mkstemp()
-        swversion.write_version(path=path)
-        with open(path) as fh:
-            contents = json.load(fh)
-        assert contents == {'version': list(fake_version_tuple), 'version_string': fake_version_string}
-        os.remove(path)
+def test_four_version():
+    """test_version | 3 digit + string tuple -> version string
+    """
+    assert swversion.get_version_string((0, 1, 0, 'alpha')) == '0.1.0-alpha'
+
+
+@pytest.mark.parametrize("version_tuple", ILLEGAL_LENGTH_VERSIONS)
+def test_illegal_len_version(version_tuple):
+    """test_version | Raise if len(version) not in (3, 4)
+    """
+    with pytest.raises(Exception):
+        swversion.get_version_string(version_tuple)
+
+
+def test_write_version(mocker, fake_version_tuple, fake_version_string):
+    mocker.patch.object(swversion, '__version__', new=fake_version_tuple)
+    mocker.patch.object(swversion, '__version_string__', new=fake_version_string)
+    _, path = tempfile.mkstemp()
+    swversion.write_version(path=path)
+    with open(path) as fh:
+        contents = json.load(fh)
+    assert contents == {'version': list(fake_version_tuple), 'version_string': fake_version_string}
+    os.remove(path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -18,6 +18,7 @@ from . import successful_queue
 assert successful_queue  # silence flake8
 
 
+# constants helpers and fixtures {{{1
 @pytest.fixture(scope='function')
 def context(tmpdir_factory):
     temp_dir = tmpdir_factory.mktemp("context", numbered=True)
@@ -42,121 +43,128 @@ def context(tmpdir_factory):
     return context
 
 
-class TestWorker(object):
-    def test_main_too_many_args(self, event_loop):
+# tests {{{1
+def test_main_too_many_args(event_loop):
+    with pytest.raises(SystemExit):
+        with mock.patch('sys.argv', new=[1, 2, 3, 4]):
+            worker.main()
+
+
+def test_main_bad_json(event_loop):
+    path = os.path.join(os.path.dirname(__file__), "data", "bad.json")
+    with pytest.raises(SystemExit):
+        with mock.patch('sys.argv', new=[__file__, path]):
+            worker.main()
+
+
+def test_main(mocker, event_loop):
+    path = os.path.join(os.path.dirname(__file__), "data", "good.json")
+    config, creds = create_config(path)
+    loop = mock.MagicMock()
+    exceptions = [RuntimeError, ScriptWorkerException]
+
+    def run_forever():
+        exc = exceptions.pop(0)
+        raise exc("foo")
+
+    def foo(arg):
+        assert arg.config == config
+        assert arg.credentials == creds
+
+    loop.run_forever = run_forever
+
+    mocker.patch.object(sys, 'argv', new=[__file__, path])
+    mocker.patch.object(worker, 'async_main', new=foo)
+    with mock.patch.object(asyncio, 'get_event_loop') as p:
+        p.return_value = loop
+        with pytest.raises(ScriptWorkerException):
+            worker.main()
+
+
+@pytest.mark.asyncio
+async def test_async_main(context):
+
+    async def exit(*args, **kwargs):
+        sys.exit()
+
+    with mock.patch('scriptworker.worker.run_loop', new=exit):
         with pytest.raises(SystemExit):
-            with mock.patch('sys.argv', new=[1, 2, 3, 4]):
-                worker.main()
+            await worker.async_main(context)
 
-    def test_main_bad_json(self, event_loop):
-        path = os.path.join(os.path.dirname(__file__), "data", "bad.json")
-        with pytest.raises(SystemExit):
-            with mock.patch('sys.argv', new=[__file__, path]):
-                worker.main()
 
-    def test_main(self, mocker, event_loop):
-        path = os.path.join(os.path.dirname(__file__), "data", "good.json")
-        config, creds = create_config(path)
-        loop = mock.MagicMock()
-        exceptions = [RuntimeError, ScriptWorkerException]
+def test_run_loop_exception(context, successful_queue, event_loop):
+    context.queue = successful_queue
 
-        def run_forever():
-            exc = exceptions.pop(0)
-            raise exc("foo")
+    async def raise_swe(*args, **kwargs):
+        raise ScriptWorkerException("foo")
 
-        def foo(arg):
-            assert arg.config == config
-            assert arg.credentials == creds
-
-        loop.run_forever = run_forever
-
-        mocker.patch.object(sys, 'argv', new=[__file__, path])
-        mocker.patch.object(worker, 'async_main', new=foo)
-        with mock.patch.object(asyncio, 'get_event_loop') as p:
-            p.return_value = loop
-            with pytest.raises(ScriptWorkerException):
-                worker.main()
-
-    @pytest.mark.asyncio
-    async def test_async_main(self, context):
-
-        async def exit(*args, **kwargs):
-            sys.exit()
-
-        with mock.patch('scriptworker.worker.run_loop', new=exit):
-            with pytest.raises(SystemExit):
-                await worker.async_main(context)
-
-    def test_run_loop_exception(self, context, successful_queue, event_loop):
-        context.queue = successful_queue
-
-        async def raise_swe(*args, **kwargs):
-            raise ScriptWorkerException("foo")
-
-        with mock.patch.object(worker, 'find_task', new=raise_swe):
-            status = event_loop.run_until_complete(worker.run_loop(context))
-
-        assert status is None
-
-    def test_mocker_run_loop(self, context, successful_queue, event_loop, mocker):
-        task = {"foo": "bar", "credentials": {"a": "b"}, "task": {'task_defn': True}}
-
-        async def find_task(*args, **kwargs):
-            return deepcopy(task)
-
-        async def noop(*args, **kwargs):
-            return
-
-        context.queue = successful_queue
-        mocker.patch.object(worker, "find_task", new=find_task)
-        mocker.patch.object(worker, "reclaim_task", new=noop)
-        mocker.patch.object(worker, "run_task", new=find_task)
-        mocker.patch.object(worker, "upload_artifacts", new=noop)
-        mocker.patch.object(worker, "complete_task", new=noop)
+    with mock.patch.object(worker, 'find_task', new=raise_swe):
         status = event_loop.run_until_complete(worker.run_loop(context))
-        assert status == task
 
-    def test_mocker_run_loop_noop(self, context, successful_queue, event_loop, mocker):
-        async def find_task(*args, **kwargs):
-            return None
+    assert status is None
 
-        async def noop(*args, **kwargs):
-            return
 
-        def noop_sync(*args, **kwargs):
-            return
+def test_mocker_run_loop(context, successful_queue, event_loop, mocker):
+    task = {"foo": "bar", "credentials": {"a": "b"}, "task": {'task_defn': True}}
 
-        context.queue = successful_queue
-        mocker.patch.object(worker, "find_task", new=find_task)
-        mocker.patch.object(worker, "reclaim_task", new=noop)
-        mocker.patch.object(worker, "run_task", new=find_task)
-        mocker.patch.object(worker, "upload_artifacts", new=noop)
-        mocker.patch.object(worker, "complete_task", new=noop)
-        mocker.patch.object(worker, "read_worker_creds", new=noop_sync)
-        status = event_loop.run_until_complete(worker.run_loop(context))
-        assert context.credentials is None
-        assert status is None
+    async def find_task(*args, **kwargs):
+        return deepcopy(task)
 
-    def test_mocker_run_loop_noop_update_creds(self, context, successful_queue,
-                                               event_loop, mocker):
-        new_creds = {"new_creds": "true"}
+    async def noop(*args, **kwargs):
+        return
 
-        async def find_task(*args, **kwargs):
-            return None
+    context.queue = successful_queue
+    mocker.patch.object(worker, "find_task", new=find_task)
+    mocker.patch.object(worker, "reclaim_task", new=noop)
+    mocker.patch.object(worker, "run_task", new=find_task)
+    mocker.patch.object(worker, "upload_artifacts", new=noop)
+    mocker.patch.object(worker, "complete_task", new=noop)
+    status = event_loop.run_until_complete(worker.run_loop(context))
+    assert status == task
 
-        async def noop(*args, **kwargs):
-            return
 
-        def get_creds(*args, **kwargs):
-            return deepcopy(new_creds)
+def test_mocker_run_loop_noop(context, successful_queue, event_loop, mocker):
+    async def find_task(*args, **kwargs):
+        return None
 
-        context.queue = successful_queue
-        mocker.patch.object(worker, "find_task", new=find_task)
-        mocker.patch.object(worker, "reclaim_task", new=noop)
-        mocker.patch.object(worker, "run_task", new=find_task)
-        mocker.patch.object(worker, "upload_artifacts", new=noop)
-        mocker.patch.object(worker, "complete_task", new=noop)
-        mocker.patch.object(worker, "read_worker_creds", new=get_creds)
-        status = event_loop.run_until_complete(worker.run_loop(context))
-        assert context.credentials == new_creds
-        assert status is None
+    async def noop(*args, **kwargs):
+        return
+
+    def noop_sync(*args, **kwargs):
+        return
+
+    context.queue = successful_queue
+    mocker.patch.object(worker, "find_task", new=find_task)
+    mocker.patch.object(worker, "reclaim_task", new=noop)
+    mocker.patch.object(worker, "run_task", new=find_task)
+    mocker.patch.object(worker, "upload_artifacts", new=noop)
+    mocker.patch.object(worker, "complete_task", new=noop)
+    mocker.patch.object(worker, "read_worker_creds", new=noop_sync)
+    status = event_loop.run_until_complete(worker.run_loop(context))
+    assert context.credentials is None
+    assert status is None
+
+
+def test_mocker_run_loop_noop_update_creds(context, successful_queue,
+                                           event_loop, mocker):
+    new_creds = {"new_creds": "true"}
+
+    async def find_task(*args, **kwargs):
+        return None
+
+    async def noop(*args, **kwargs):
+        return
+
+    def get_creds(*args, **kwargs):
+        return deepcopy(new_creds)
+
+    context.queue = successful_queue
+    mocker.patch.object(worker, "find_task", new=find_task)
+    mocker.patch.object(worker, "reclaim_task", new=noop)
+    mocker.patch.object(worker, "run_task", new=find_task)
+    mocker.patch.object(worker, "upload_artifacts", new=noop)
+    mocker.patch.object(worker, "complete_task", new=noop)
+    mocker.patch.object(worker, "read_worker_creds", new=get_creds)
+    status = event_loop.run_until_complete(worker.run_loop(context))
+    assert context.credentials == new_creds
+    assert status is None


### PR DESCRIPTION
This function both validates a URL is not pointing off at some untrusted external resource, and returns what we believe is the filepath of the resource.  The filepath can include some relative directory paths, which helps differentiate artifacts that have the same filename, but different filepaths.