### PR TITLE
Artifact subdirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - test files no longer use a test class.
+- `upload_artifacts` now uploads files in subdirectories of `artifact_dir`, preserving the relative paths.
 
 ### Removed
 - Removed unneeded creds file generation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+## [0.4.0] - 2016-08-19
 ### Added
 - add `scriptworker.utils.filepaths_in_dir`
 - added setup.cfg for wheels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- add `scriptworker.utils.filepaths_in_dir`
 - added setup.cfg for wheels
 - added `scriptworker.client.validate_artifact_url`.
 

--- a/config_example.json
+++ b/config_example.json
@@ -13,7 +13,7 @@
     "task_max_timeout": 1200,
     "valid_artifact_schemes": ["https"],
     "valid_artifact_netlocs": ["queue.taskcluster.net"],
-    "valid_artifact_path_regexes": ["^/v1/task/(?P<taskId>[^/]+)/artifacts/(?P<filepath>.*)$"],
+    "valid_artifact_path_regexes": ["^/v1/task/(?P<taskId>[^/]+)(/runs/\d+)?/artifacts/(?P<filepath>.*)$"],
 
     "credentials": {
         "clientId": "...",

--- a/scriptworker/config.py
+++ b/scriptworker/config.py
@@ -28,7 +28,7 @@ DEFAULT_CONFIG = {
     'valid_artifact_schemes': ('https', ),
     'valid_artifact_netlocs': ('queue.taskcluster.net', ),
     'valid_artifact_path_regexes': (
-        r'''^/v1/task/(?P<taskId>[^/]+)/artifacts/(?P<filepath>.*)$''',
+        r'''^/v1/task/(?P<taskId>[^/]+)(/runs/\d+)?/artifacts/(?P<filepath>.*)$''',
     ),
     'valid_artifact_task_ids': (),
 

--- a/scriptworker/task.py
+++ b/scriptworker/task.py
@@ -206,6 +206,8 @@ async def complete_task(context, result):
 
 
 async def kill(pid, sleep_time=1):
+    """Kill `pid`.
+    """
     siglist = [signal.SIGINT, signal.SIGTERM]
     while True:
         sig = signal.SIGKILL
@@ -220,6 +222,11 @@ async def kill(pid, sleep_time=1):
 
 
 def max_timeout(context, proc, timeout):
+    """Make sure the proc pid's process and process group are killed.
+    """
+    # We may be called with proc1.  proc1 may finish, and proc2 may start
+    # before this function is called.  Make sure we're still running the
+    # proc we were called with.
     if proc != context.proc:
         return
     pid = context.proc.pid

--- a/scriptworker/utils.py
+++ b/scriptworker/utils.py
@@ -127,3 +127,16 @@ async def raise_future_exceptions(tasks):
         exc = task.exception()
         if exc is not None:
             raise exc
+
+
+def filepaths_in_dir(path):
+    """Given a directory path, find all files in that directory, and return
+    the relative paths to those files.
+    """
+    filepaths = []
+    for root, directories, filenames in os.walk(path):
+        for filename in filenames:
+            filepath = os.path.join(root, filename)
+            filepath = filepath.replace(path, '').lstrip('/')
+            filepaths.append(filepath)
+    return filepaths

--- a/scriptworker/utils.py
+++ b/scriptworker/utils.py
@@ -38,6 +38,8 @@ async def request(context, url, timeout=60, method='get', good=(200, ),
 
 async def retry_request(*args, retry_exceptions=(ScriptWorkerRetryException, ),
                         **kwargs):
+    """Retry the `request` function
+    """
     return await retry_async(request, retry_exceptions=retry_exceptions,
                              args=args, kwargs=kwargs)
 
@@ -80,6 +82,8 @@ def cleanup(context):
 
 async def retry_async(func, attempts=5, sleeptime_callback=None,
                       retry_exceptions=(Exception, ), args=(), kwargs=None):
+    """Retry `func`, where `func` is an awaitable.
+    """
     kwargs = kwargs or {}
     sleeptime_callback = sleeptime_callback or calculateSleepTime
     attempt = 1
@@ -98,6 +102,8 @@ async def retry_async(func, attempts=5, sleeptime_callback=None,
 
 def create_temp_creds(client_id, access_token, start=None, expires=None,
                       scopes=None, name=None):
+    """Create temp TC creds from our permanent creds.
+    """
     now = arrow.utcnow().replace(minutes=-10)
     start = start or now.datetime
     expires = expires or now.replace(days=31).datetime
@@ -113,6 +119,9 @@ def create_temp_creds(client_id, access_token, start=None, expires=None,
 
 
 async def raise_future_exceptions(tasks):
+    """Given a list of futures, await them, then raise their exceptions if
+    any.  Without something like this, any exceptions will be ignored.
+    """
     await asyncio.wait(tasks)
     for task in tasks:
         exc = task.exception()

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -49,7 +49,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (0, 3, 1, "alpha")
+__version__ = (0, 4, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,8 +11,18 @@ import taskcluster.exceptions
 
 
 def read(path):
+    """Return the contents of a file.
+    """
     with open(path, "r") as fh:
         return fh.read()
+
+
+def touch(path):
+    """ Create an empty file.  Different from the system 'touch' in that it
+    will overwrite an existing file.
+    """
+    with open(path, "w") as fh:
+        print(path, file=fh, end="")
 
 
 class SuccessfulQueue(object):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -16,18 +16,13 @@ import sys
 import taskcluster.exceptions
 import taskcluster.async
 import time
-from . import fake_session, fake_session_500, successful_queue, unsuccessful_queue, read
+from . import fake_session, fake_session_500, successful_queue, touch, unsuccessful_queue, read
 
 assert fake_session, fake_session_500  # silence flake8
 assert successful_queue, unsuccessful_queue  # silence flake8
 
 # constants helpers and fixtures {{{1
 TIMEOUT_SCRIPT = os.path.join(os.path.dirname(__file__), "data", "long_running.py")
-
-
-def touch(path):
-    with open(path, "w") as fh:
-        print(path, file=fh, end="")
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -9,7 +9,7 @@ import mock
 import os
 import pytest
 from scriptworker.context import Context
-from scriptworker.exceptions import ScriptWorkerRetryException
+from scriptworker.exceptions import ScriptWorkerRetryException, ScriptWorkerTaskException
 import scriptworker.task as task
 import scriptworker.log as log
 import sys
@@ -150,11 +150,11 @@ async def test_reclaim_task_non_409(context, successful_queue):
 @pytest.mark.asyncio
 async def test_upload_artifacts(context):
     args = []
-    os.makedirs(context.config['artifact_dir'])
+    os.makedirs(os.path.join(context.config['artifact_dir'], 'public'))
     os.makedirs(context.config['log_dir'])
     paths = list(log.get_log_filenames(context)) + [
         os.path.join(context.config['artifact_dir'], 'one'),
-        os.path.join(context.config['artifact_dir'], 'two'),
+        os.path.join(context.config['artifact_dir'], 'public/two'),
     ]
     for path in paths:
         touch(path)
@@ -168,6 +168,20 @@ async def test_upload_artifacts(context):
     assert sorted(args) == sorted(paths)
 
 
+def test_bad_update_upload_file_list():
+    with pytest.raises(ScriptWorkerTaskException):
+        task._update_upload_file_list(
+            {'existing_key': {
+                'path': 'one',
+                'target_path': 'existing_key',
+            }},
+            {
+                'path': 'two',
+                'target_path': 'existing_key'
+            }
+        )
+
+
 @pytest.mark.asyncio
 async def test_create_artifact(context, fake_session, successful_queue):
     path = os.path.join(context.config['artifact_dir'], "one.txt")
@@ -177,7 +191,7 @@ async def test_create_artifact(context, fake_session, successful_queue):
     expires = arrow.utcnow().isoformat()
     with mock.patch('scriptworker.task.get_temp_queue') as p:
         p.return_value = successful_queue
-        await task.create_artifact(context, path, expires=expires)
+        await task.create_artifact(context, path, "public/env/one.txt", expires=expires)
     assert successful_queue.info == [
         "createArtifact", ('taskId', 'runId', "public/env/one.txt", {
             "storageType": "s3",
@@ -198,7 +212,7 @@ async def test_create_artifact_retry(context, fake_session_500, successful_queue
     with pytest.raises(ScriptWorkerRetryException):
         with mock.patch('scriptworker.task.get_temp_queue') as p:
             p.return_value = successful_queue
-            await task.create_artifact(context, path, expires=expires)
+            await task.create_artifact(context, path, "public/env/one.log", expires=expires)
     context.session.close()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,10 +6,11 @@ import asyncio
 import mock
 import os
 import pytest
+import tempfile
 from scriptworker.context import Context
 from scriptworker.exceptions import ScriptWorkerException, ScriptWorkerRetryException
 import scriptworker.utils as utils
-from . import fake_session, fake_session_500, FakeResponse
+from . import fake_session, fake_session_500, FakeResponse, touch
 
 assert fake_session, fake_session_500  # silence flake8
 
@@ -198,3 +199,18 @@ async def test_raise_future_exceptions(event_loop):
     tasks = [asyncio.ensure_future(one()), asyncio.ensure_future(two())]
     with pytest.raises(IOError):
         await utils.raise_future_exceptions(tasks)
+
+
+def test_filepaths_in_dir():
+    filepaths = sorted([
+        "asdfasdf/lwekrjweoi/lsldkfjs",
+        "lkdsjf/werew/sdlkfds",
+        "lsdkjf/sdlkfds",
+        "lkdlkf/lsldkfjs",
+    ])
+    with tempfile.TemporaryDirectory() as tmp:
+        for path in filepaths:
+            parent_dir = os.path.join(tmp, os.path.dirname(path))
+            os.makedirs(parent_dir)
+            touch(os.path.join(tmp, path))
+        assert sorted(utils.filepaths_in_dir(tmp)) == filepaths

--- a/version.json
+++ b/version.json
@@ -1,9 +1,8 @@
 {
     "version": [
-        0, 
-        3, 
-        1, 
-        "alpha"
-    ], 
-    "version_string": "0.3.1-alpha"
+        0,
+        4,
+        0
+    ],
+    "version_string": "0.4.0"
 }


### PR DESCRIPTION
Previously, scriptworker required a flat `artifact_dir`, and used `glob.glob` to find all files, and uploaded them to `public/env/FILENAME`.  I wanted to eventually support subdirectories in `artifact_dir`, but saw no pressing need to add it immediately.

@acmiyaguchi found that the Android builds use the same filename, but different subdirectories.  Because we're using a flat `artifact_dir`, one overwrites the other.

This is the third set of commits to support subdirs.  The previous two dealt with `scriptworker.client.validate_artifact_url`:
* https://github.com/mozilla-releng/scriptworker/pull/7
* https://github.com/mozilla-releng/signingscript/pull/8

This has to do with the artifact uploads.