### PR TITLE
0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+## [0.7.0] - 2016-09-23
 ### Added
 - added `DownloadError` exception for `download_file`
 - added `scriptworker.task.download_artifacts`

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -49,7 +49,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (0, 6, 0)
+__version__ = (0, 7, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
         0,
-        6,
+        7,
         0
     ],
-    "version_string": "0.6.0"
+    "version_string": "0.7.0"
 }


### PR DESCRIPTION
I thought about holding off for more cot work, but the signingscript download_artifacts changes aren't easily tested without a new release.

I also thought about 0.6.1 but this is non-backwards-compatible, so 0.7.0 it is.  I was thinking about bumping to 1.0.0 when cot was fully implemented anyway.