### PR TITLE
0.8.1: explicitly pass taskId and runId from the azure json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+## [0.8.1] - 2016-10-18
 ### Fixed
 - explicitly pass `taskId` and `runId` to `claim_task`.  There's a new `hintId` property that appears in `message_info['task_info']` that broke things.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+- explicitly pass `taskId` and `runId` to `claim_task`.  There's a new `hintId` property that appears in `message_info['task_info']` that broke things.
 
 ## [0.8.0] - 2016-10-13
 ### Added

--- a/scriptworker/poll.py
+++ b/scriptworker/poll.py
@@ -117,7 +117,7 @@ async def find_task(context, poll_url, delete_url, request_function):
     """
     xml = await request_function(context, poll_url)
     for message_info in parse_azure_xml(xml):
-        task = await claim_task(context, **message_info['task_info'])
+        task = await claim_task(context, message_info['task_info']['taskId'], message_info['task_info']['runId'])
         if task is not None:
             log.info("Found task! Deleting from azure...")
             delete_url = delete_url.replace("{{", "{").replace("}}", "}").format(**message_info)

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -49,7 +49,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (0, 8, 1, "alpha1")
+__version__ = (0, 8, 1)
 __version_string__ = get_version_string(__version__)
 
 

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -49,7 +49,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (0, 8, 0)
+__version__ = (0, 8, 1, "alpha1")
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,8 +2,7 @@
     "version": [
         0,
         8,
-        1,
-        "alpha1"
+        1
     ],
-    "version_string": "0.8.1-alpha1"
+    "version_string": "0.8.1"
 }

--- a/version.json
+++ b/version.json
@@ -2,7 +2,8 @@
     "version": [
         0,
         8,
-        0
+        1,
+        "alpha1"
     ],
-    "version_string": "0.8.0"
+    "version_string": "0.8.1-alpha1"
 }


### PR DESCRIPTION
I've been assuming that `message_info['task_info']` will always look like

```python
{
    "taskId": "...",
    "runId": 0
}
```

However, in [this changeset](https://github.com/taskcluster/taskcluster-queue/pull/124/files#diff-2ba94b1f0cbf39f965dbec5a3f38019cR592), @jonasfj added a `hintId`.

This change explicitly passes `taskId` and `runId` rather than using `message_info['task_info']` as kwargs.

After pushing this patch, and a puppet-specific change, to puppet, the signing scriptworkers began claiming new tasks again.