### PR TITLE
0.8.2: fix polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- logged the stacktrace if the `main` loop hits an exception.  No longer catch and ignore `RuntimeError`, since it wasn't clear why that was put in.
+- updated `check_config` to make sure taskcluster-related configs match taskcluster requirements
+
+### Fixed
+- changed the way the polling loop works: `async_main` is now a single pass, which `main` calls in a `while True` loop.  This should fix the situation where polling was dying silently while the git update loop continued running every 5 minutes.
 
 ## [0.8.1] - 2016-10-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+## [0.8.2] - 2016-10-24
 ### Changed
 - logged the stacktrace if the `main` loop hits an exception.  No longer catch and ignore `RuntimeError`, since it wasn't clear why that was put in.
 - updated `check_config` to make sure taskcluster-related configs match taskcluster requirements

--- a/scriptworker/gpg.py
+++ b/scriptworker/gpg.py
@@ -1399,7 +1399,6 @@ async def rebuild_gpg_homedirs_loop(context, basedir):
             without the lockfile means we're waiting to overwrite our gpg homedirs
             with the contents of this tmp dir.
     """
-    rm(basedir)
     if not context.config['sign_chain_of_trust'] and not context.config['verify_chain_of_trust']:
         log.warning("sign_chain_of_trust and verify_chain_of_trust are False; exiting rebuild_gpg_homedirs_loop!")
         return

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -49,7 +49,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (0, 8, 1)
+__version__ = (0, 8, 2)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         0,
         8,
-        1
+        2
     ],
-    "version_string": "0.8.1"
+    "version_string": "0.8.2"
 }


### PR DESCRIPTION
* The symptoms involved the polling dying, but not the git pull.  Instead of relying on a single `create_task` and then an `loop.run_forever()` to poll, put a `loop.run_until_complete()` inside a `while True` loop.  The git pulls are happening every 5 minutes as desired, and the taskcluster polling is still going.

* Log the traceback if we hit any exceptions running `async_main`.  I noticed that supervisor was restarting the process a lot while github was down on Friday, and I wasn't sure what was breaking.  This should give us more info.

* Remove the `rebuild_gpg_homedirs_loop()` basedir after we're done copying the contents, instead of at the beginning of the call.  This helps avoid having background processes step on each other.  We may end up having to monitor the tmpdir for freshness if the git pull hangs, but that hasn't been an issue so far.

Once I get review, I'm going to bump to 0.8.2 and merge, then cherry pick the fixes onto the 0.7.x branch for 0.7.2.

@JohanLorenzo , until @lundjordan gets back you're the one with the most scriptworker background; are you up for the review?