### PR TITLE
config: Enforce the 22-character-limit imposed by Taskcluster

### DIFF
--- a/scriptworker/test/test_config.py
+++ b/scriptworker/test/test_config.py
@@ -74,6 +74,13 @@ def test_check_config_bad_keyring(t_config):
     assert "needs to start with %(gpg_home)s/" in "\n".join(messages)
 
 
+@pytest.mark.parametrize("params", ("provisioner_id", "worker_group", "worker_type", "worker_id"))
+def test_check_config_invalid_ids(params, t_config):
+    t_config[params] = 'twenty-three-characters'
+    messages = config.check_config(t_config, "test_path")
+    assert '{} doesn\'t match "^[a-zA-Z0-9-_]{{1,22}}$" (required by Taskcluster)'.format(params) in messages
+
+
 def test_check_config_good(t_config):
     for key, value in t_config.items():
         if value == "...":


### PR DESCRIPTION
Like discussed [in this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1306307#c9), taskcluster doesn't allow more than 22 characters for IDs. If an instance is configured with an invalid ID, the failure occurs only when the first task is being handled. As @catlee suggested offline, we can fail earlier, like when the configuration is parsed.