### PR TITLE
0.9.0: Pull gpg homedir creation out of the main scriptworker process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+## [0.9.0] - 2016-11-01
 ### Added
 - `gpg_lockfile` and `last_good_git_revision_file` in config
 - `get_last_good_git_revision` and `write_last_good_git_revision` now return the last good git revision, and write it to `last_good_git_revision_file`, respectively.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `get_last_good_git_revision` and `write_last_good_git_revision` now return the last good git revision, and write it to `last_good_git_revision_file`, respectively.
 - `get_tmp_base_gpg_home_dir` is a helper function to avoid duplication in logic.
 - `rebuild_gpg_homedirs` is a new entry point script that allows us to recreate the gpg homedirs in a tmpdir, in a separate process
-- `check_lockfile`, `create_lockfile`, and `rm_lockfile` as helper functions for the two gpg homedir entry points.
+- `is_lockfile_present`, `create_lockfile`, and `rm_lockfile` as helper functions for the two gpg homedir entry points.
 
 ### Changed
 - `sign_key`, `rebuild_gpg_home_flat`, `rebuild_gpg_home_signed`, `build_gpg_homedirs_from_repo` are no longer async.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+- `gpg_lockfile` and `last_good_git_revision_file` in config
+- `get_last_good_git_revision` and `write_last_good_git_revision` now return the last good git revision, and write it to `last_good_git_revision_file`, respectively.
+- `get_tmp_base_gpg_home_dir` is a helper function to avoid duplication in logic.
+- `rebuild_gpg_homedirs` is a new entry point script that allows us to recreate the gpg homedirs in a tmpdir, in a separate process
+
+### Changed
+- `sign_key`, `rebuild_gpg_home_flat`, `rebuild_gpg_home_signed`, `build_gpg_homedirs_from_repo` are no longer async.
+- `overwrite_gpg_home` only keeps one backup.
+- `update_signed_git_repo` now returns the latest git revision, instead of a boolean marking whether the revision is new or not.  This will help avoid the scenario where we update, fail to generate the gpg homedirs, and then stay on an old revision until the next push.
+- `update_logging_config` now takes a `file_name` kwarg, which allows us to create new log files for the `rebuild_gpg_homedirs` and `create_initial_gpg_homedirs` entry points.
+
+### Fixed
+- `build_gpg_homedirs_from_repo` now waits to verify the contents of the updated git repo before nuking the previous base gpg homedir.
+- `create_initial_gpg_homedirs` now creates a logfile
+
+### Removed
+- `rebuild_gpg_homedirs_loop` is no longer needed, and is removed.
 
 ## [0.8.2] - 2016-10-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `get_last_good_git_revision` and `write_last_good_git_revision` now return the last good git revision, and write it to `last_good_git_revision_file`, respectively.
 - `get_tmp_base_gpg_home_dir` is a helper function to avoid duplication in logic.
 - `rebuild_gpg_homedirs` is a new entry point script that allows us to recreate the gpg homedirs in a tmpdir, in a separate process
+- `check_lockfile`, `create_lockfile`, and `rm_lockfile` as helper functions for the two gpg homedir entry points.
 
 ### Changed
 - `sign_key`, `rebuild_gpg_home_flat`, `rebuild_gpg_home_signed`, `build_gpg_homedirs_from_repo` are no longer async.

--- a/config_example.json
+++ b/config_example.json
@@ -10,6 +10,8 @@
     "task_log_dir": "/tmp/artifact/public/logs",
     "git_key_repo_dir": "/tmp/key_repo",
     "base_gpg_home_dir": "/tmp/gpg",
+    "gpg_lockfile": "/tmp/gpg_homedir.lock",
+    "last_good_git_revision_file": "/tmp/git_revision",
 
     "my_email": "scriptworker@example.com",
 

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -62,6 +62,7 @@ DEFAULT_CONFIG = frozendict({
     # Boolean to use the gpg agent
     "gpg_use_agent": False,
     "gpg_encoding": 'utf-8',
+    "gpg_lockfile": os.path.join(os.getcwd(), "gpg_homedir.lock"),
 
     # Worker log settings
     "log_datefmt": "%Y-%m-%dT%H:%M:%S",
@@ -69,13 +70,15 @@ DEFAULT_CONFIG = frozendict({
     "log_max_bytes": 1024 * 1024 * 512,
     "log_num_backups": 10,
 
+    "git_key_repo_dir": "...",
+    "base_gpg_home_dir": "...",
+    "last_good_git_revision_file": os.path.join(os.getcwd(), "git_revision"),
+
     # Task settings
     "work_dir": "...",
     "log_dir": "...",
     "artifact_dir": "...",
     "task_log_dir": "...",  # set this to ARTIFACT_DIR/public/logs
-    "git_key_repo_dir": "...",
-    "base_gpg_home_dir": "...",
     "artifact_expiration_hours": 24,
     "artifact_upload_timeout": 60 * 20,
     "sign_key_timeout": 60 * 2,

--- a/scriptworker/gpg.py
+++ b/scriptworker/gpg.py
@@ -1337,20 +1337,14 @@ def write_last_good_git_revision(context, revision):
     Args:
         context (scriptworker.context.Context): the scriptworker context.
         revision (str): the last good git revision
-
-    Raises:
-        ScriptWorkerGPGException: on failure
     """
     log.info(
         "writing last_good_git_revision {} to {}...".format(
             revision, context.config['last_good_git_revision_file']
         )
     )
-    try:
-        with open(context.config['last_good_git_revision_file'], "w") as fh:
-            print(revision, file=fh, end='')
-    except OSError as exc:
-        raise ScriptWorkerGPGException(str(exc))
+    with open(context.config['last_good_git_revision_file'], "w") as fh:
+        fh.write(revision)
 
 
 # build gpg homedirs from repo {{{1
@@ -1449,7 +1443,7 @@ def create_initial_gpg_homedirs():
     context, _ = get_context_from_cmdln(sys.argv[1:])
     update_logging_config(context, file_name='create_initial_gpg_homedirs.log')
     log.info("create_initial_gpg_homedirs()...")
-    if check_lockfile(context, "create_initial_gpg_homedirs"):
+    if is_lockfile_present(context, "create_initial_gpg_homedirs"):
         return
     makedirs(context.config['git_key_repo_dir'])
     create_lockfile(context)
@@ -1477,7 +1471,7 @@ def get_tmp_base_gpg_home_dir(context):
     return '{}.tmp'.format(context.config['base_gpg_home_dir'])
 
 
-def check_lockfile(context, name):
+def is_lockfile_present(context, name):
     """Check for the lockfile.
 
     Args:
@@ -1491,6 +1485,7 @@ def check_lockfile(context, name):
     if os.path.exists(lockfile):
         log.warning("Skipping {}: lockfile {} exists!".format(name, lockfile))
         return True
+    return False
 
 
 def create_lockfile(context):
@@ -1525,7 +1520,7 @@ def rebuild_gpg_homedirs():
     update_logging_config(context, file_name='rebuild_gpg_homedirs.log')
     log.info("rebuild_gpg_homedirs()...")
     basedir = get_tmp_base_gpg_home_dir(context)
-    if check_lockfile(context, "rebuild_gpg_homedirs"):
+    if is_lockfile_present(context, "rebuild_gpg_homedirs"):
         return
     create_lockfile(context)
     try:

--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -15,7 +15,7 @@ from scriptworker.utils import makedirs, to_unicode
 log = logging.getLogger(__name__)
 
 
-def update_logging_config(context, log_name=None):
+def update_logging_config(context, log_name=None, file_name='worker.log'):
     """Update python logging settings from config.
 
     By default, this sets the `scriptworker` log settings, but this will
@@ -49,7 +49,7 @@ def update_logging_config(context, log_name=None):
 
     # Rotating log file
     makedirs(context.config['log_dir'])
-    path = os.path.join(context.config['log_dir'], 'worker.log')
+    path = os.path.join(context.config['log_dir'], file_name)
     handler = logging.handlers.RotatingFileHandler(
         path, maxBytes=context.config['log_max_bytes'],
         backupCount=context.config['log_num_backups'],

--- a/scriptworker/test/test_gpg.py
+++ b/scriptworker/test/test_gpg.py
@@ -921,5 +921,5 @@ def test_write_last_good_git_revision_exception(context, mocker):
         raise OSError("blah")
 
     mocker.patch.object(sgpg, "open", new=boom)
-    with pytest.raises(ScriptWorkerGPGException):
+    with pytest.raises(OSError):
         sgpg.write_last_good_git_revision(context, "foo")

--- a/scriptworker/test/test_worker.py
+++ b/scriptworker/test/test_worker.py
@@ -81,7 +81,6 @@ def test_main(mocker, context, event_loop):
         with open(tmp, "w") as fh:
             json.dump(config, fh)
         del(config['credentials'])
-        mocker.patch.object(worker, 'rebuild_gpg_homedirs_loop', new=noop_async)
         mocker.patch.object(worker, 'async_main', new=foo)
         mocker.patch.object(sys, 'argv', new=['x', tmp])
         with mock.patch.object(asyncio, 'get_event_loop') as p:
@@ -102,7 +101,7 @@ def test_async_main(context, event_loop, mocker, tmpdir):
             os.makedirs(path)
         except FileExistsError:
             pass
-        lockfile = os.path.join(path, ".lock")
+        lockfile = context.config['gpg_lockfile']
         if os.path.exists(lockfile):
             os.remove(lockfile)
         else:

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -49,7 +49,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (0, 8, 2)
+__version__ = (0, 9, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "console_scripts": [
             "scriptworker = scriptworker.worker:main",
             "create_initial_gpg_homedirs = scriptworker.gpg:create_initial_gpg_homedirs",
+            "rebuild_gpg_homedirs = scriptworker.gpg:rebuild_gpg_homedirs",
         ],
     },
     zip_safe=False,

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
         0,
-        8,
-        2
+        9,
+        0
     ],
-    "version_string": "0.8.2"
+    "version_string": "0.9.0"
 }


### PR DESCRIPTION
Per the commit message:

```
Originally, gpg homedir creation happened before scriptworker launched,
and then a background async task polled git and rebuilt the gpg homedirs
if it found a new valid git commit.  In order to sign the gpg keys in
the background, we used async pexpect.

However, as noted in #21, async pexpect isn't reliable currently.  Our
options included fixing the upstream pexpect bug or pulling the gpg
homedir creation into a separate process that we can call via cron.

This patch allows us to use that latter approach.
```

Fixes #21 .

@JohanLorenzo , I'll let you thumb wrestle with @lundjordan with review now that he's back :)  I'm happy to have either of you review.  Thanks to both of you!

I'm going to release scriptworker 0.9.0 off this PR once it's approved.
