### PR TITLE
Bug 1314840 monitoring

### DIFF
--- a/scriptworker/monitoring/nagios_file_age_check.py
+++ b/scriptworker/monitoring/nagios_file_age_check.py
@@ -143,6 +143,3 @@ def run_file_age_checks():
 
     print("{0}\n{1}\n".format(service_output, "\n".join(sorted(messages))))
     sys.exit(exit_code)
-
-if __name__ == '__main__':
-    run_file_age_checks()

--- a/scriptworker/monitoring/nagios_file_age_check.py
+++ b/scriptworker/monitoring/nagios_file_age_check.py
@@ -4,7 +4,7 @@
 Checks for the existence and age of specific files, and that they are not
 too old.
 
-Allow 'old' to be defined as warning and critical arguments. 
+Allow 'old' to be defined as warning and critical arguments.
 
 You can either:
 - Specify one file to check
@@ -70,7 +70,7 @@ def file_age_check(filename, warning, critical, optional):
         return STATUS_CODE['CRITICAL'], msg
     else:
         msg = "{0} is ok, {1}/{2} seconds old".format(
-            filename, int(age), max_age)
+            filename, int(age), critical)
         return STATUS_CODE['OK'], msg
 
 

--- a/scriptworker/monitoring/nagios_file_age_check.py
+++ b/scriptworker/monitoring/nagios_file_age_check.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+
+"""
+Checks for the existence and age of specific files, and that they are not
+too old.
+
+Allow 'old' to be defined as warning and critical arguments. 
+
+"""
+import os
+import sys
+import time
+import argparse
+
+# Nagios plugin exit codes
+STATUS_CODE = {
+    'OK': 0,
+    'WARNING': 1,
+    'CRITICAL': 2,
+    'UNKNOWN': 3,
+}
+
+DEFAULT_WARNING = 45
+DEFAULT_CRITICAL = 60
+
+
+def file_age_check(filename, warning, critical, optional):
+    """file_age_check
+
+    Checks the age and existence of a given filename
+
+    Arguments:
+      - filename: a string, containing a full path
+      - warning: integer, time in seconds over which to issue a warning.
+      - critical: integer, time in seconds over which to issue critical.
+
+    Returns:
+      Tuple:
+        - nagios status code from global STATUS_CODE
+        - message string to be given to nagios
+    """
+
+    if not os.path.isfile(filename):
+        if optional:
+            return STATUS_CODE['OK'], "{0} doesn't exist and that's ok".format(filename)
+        else:
+            return STATUS_CODE['CRITICAL'], "{0} does not exist".format(filename)
+
+    try:
+        st = os.stat(filename)
+    except OSError as excp:
+        return STATUS_CODE['UNKNOWN'], "{0}: {1}".format(filename, excp)
+    current_time = time.time()
+    age = current_time - st.st_mtime
+
+    if age >= critical:
+        msg = "{0} is too old {1}/{2} seconds".format(
+            filename, int(age), critical)
+        return STATUS_CODE['CRITICAL'], msg
+    elif age >= warning:
+        msg = "{0} is getting too old {1}/{2} seconds".format(
+            filename, int(age), warning)
+        return STATUS_CODE['CRITICAL'], msg
+    else:
+        msg = "{0} is ok, {1}/{2} seconds old".format(
+            filename, int(age), max_age)
+        return STATUS_CODE['OK'], msg
+
+
+def get_args():
+
+    argp = argparse.ArgumentParser(description=__doc__)
+    argp.add_argument('-w', '--warning', type=int, default=DEFAULT_WARNING,
+                      help='warn if files are older than this many minutes')
+    argp.add_argument('-c', '--critical', type=int, default=DEFAULT_CRITICAL,
+                      help='critical if files are older than this many minutes')
+
+    argp.add_argument('-o', '--optional', action='store_true',
+                      help="If set, do not report error if the file is missing")
+
+    arggroup = argp.add_mutually_exclusive_group(required=True)
+
+    arggroup.add_argument('-p', '--path', type=str,
+                          help="The full path name to check")
+    arggroup.add_argument('-f', '--from-file',
+                          type=argparse.FileType('r'),
+                          default=sys.stdin,
+                          help="A file of paths to check, one per line, or - for stdin (default)")
+
+    args = argp.parse_args()
+
+    # convert to seconds for epoch time comparison
+    args.warning = args.warning * 60
+    args.critical = args.critical * 60
+
+    return args
+
+
+def run_file_age_checks():
+    """run_file_age_checks
+    Organise the file age checks for nagios
+
+    Output:
+    Prints to stdout
+    Exits with appropriate return code"""
+
+    args = get_args()
+
+    statuses = list()
+    messages = list()
+
+    if args.path:
+        check_files = [args.path]
+    else:
+        check_files = [f.strip() for f in args.from_file]
+
+    for filename in check_files:
+        status, message = file_age_check(
+            filename, args.warning, args.critical, args.optional)
+        statuses.append(status)
+        messages.append(message)
+
+    exit_code = max(statuses)
+
+    reverse_status_codes = {v: k for k, v in STATUS_CODE.items()}
+    service_output = "FILE_AGE {0}".format(reverse_status_codes[exit_code])
+
+    service_output_options = {
+        STATUS_CODE['OK']: "All files ok",
+        STATUS_CODE['WARNING']: "Some files may be too old, see long output",
+        STATUS_CODE['CRITICAL']: "Some files errored, see long output",
+        STATUS_CODE['UNKNOWN']: "Unknown error",
+    }
+
+    service_output += " - {0}".format(service_output_options[exit_code])
+
+    print("{0}\n{1}\n".format(service_output, "\n".join(sorted(messages))))
+    sys.exit(exit_code)
+
+if __name__ == '__main__':
+    run_file_age_checks()

--- a/scriptworker/monitoring/nagios_file_age_check.py
+++ b/scriptworker/monitoring/nagios_file_age_check.py
@@ -6,6 +6,13 @@ too old.
 
 Allow 'old' to be defined as warning and critical arguments. 
 
+You can either:
+- Specify one file to check
+- Give the path to a file, that contains a newline-separated list
+  of the files to check.
+
+This script will produce a multi-line nagios report in either case.
+
 """
 import os
 import sys

--- a/scriptworker/monitoring/nagios_pending_tasks.py
+++ b/scriptworker/monitoring/nagios_pending_tasks.py
@@ -7,7 +7,6 @@ Entrypoint for pending tasks monitoring.
 import asyncio
 import aiohttp
 import sys
-import json
 import argparse
 
 

--- a/scriptworker/monitoring/nagios_pending_tasks.py
+++ b/scriptworker/monitoring/nagios_pending_tasks.py
@@ -73,9 +73,6 @@ def query_pending_task_count():
         except Exception as excp:
             nagios_message(
                 'UNKNOWN', 'Unable to query pending tasks: {0}'.format(excp))
-            #log.critical("Fatal exception", exc_info=1)
-            # raise
-        # {'provisionerId': 'test-dummy-provisioner', 'pendingTasks': 0, 'workerType': 'dummy-worker-myname'}
 
         template = '{pending}/{max} pending tasks for {provisioner}:{worker}'
 

--- a/scriptworker/monitoring/nagios_pending_tasks.py
+++ b/scriptworker/monitoring/nagios_pending_tasks.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+"""
+Entrypoint for pending tasks monitoring.
+
+"""
+import asyncio
+import aiohttp
+import sys
+import json
+import argparse
+
+
+from scriptworker.config import get_context_from_cmdln
+from scriptworker.utils import cleanup
+
+
+# Nagios plugin exit codes
+STATUS_CODE = {
+    'OK': 0,
+    'WARNING': 1,
+    'CRITICAL': 2,
+    'UNKNOWN': 3,
+}
+
+DEFAULT_WARNING = 5
+DEFAULT_CRITICAL = 10
+
+
+def nagios_message(status, message):
+    """nagios_message
+    display a message in the nagios style, and exit appropriately
+    """
+    print("PENDING_TASKS {0} - {1}".format(status, message))
+    sys.exit(STATUS_CODE[status])
+
+
+def get_args():
+
+    argp = argparse.ArgumentParser(description=__doc__)
+    argp.add_argument('-w', '--warning', type=int, default=DEFAULT_WARNING,
+                      help='warning threshhold for number of pending tasks')
+    argp.add_argument('-c', '--critical', type=int, default=DEFAULT_CRITICAL,
+                      help='critical threshhold for number of pending tasks')
+
+    args = argp.parse_args()
+
+    return args
+
+
+def query_pending_task_count():
+    """query_pending_task_count
+    Query the API for the number of pending tasks, so we can
+    report to nagios
+    """
+
+    args = get_args()
+
+    context, credentials = get_context_from_cmdln(sys.argv[1:])
+    cleanup(context)
+
+    conn = aiohttp.TCPConnector(
+        limit=context.config['aiohttp_max_connections'])
+    loop = asyncio.get_event_loop()
+    with aiohttp.ClientSession(connector=conn) as session:
+        context.session = session
+        context.credentials = credentials
+
+        try:
+            result = loop.run_until_complete(context.queue.pendingTasks(
+                context.config['provisioner_id'], context.config['worker_type']))
+
+        except Exception as excp:
+            nagios_message(
+                'UNKNOWN', 'Unable to query pending tasks: {0}'.format(excp))
+            #log.critical("Fatal exception", exc_info=1)
+            # raise
+        # {'provisionerId': 'test-dummy-provisioner', 'pendingTasks': 0, 'workerType': 'dummy-worker-myname'}
+
+        template = '{pending}/{max} pending tasks for {provisioner}:{worker}'
+
+        if result['pendingTasks'] >= args.critical:
+            nagios_message(
+                'CRITICAL', template.format(
+                    pending=result['pendingTasks'],
+                    max=args.critical,
+                    provisioner=result['provisionerId'],
+                    worker=result['workerType']
+                )
+            )
+        elif result['pendingTasks'] >= args.warning:
+            nagios_message(
+                'WARNING', "{0}/{1} pending tasks".format(result['pendingTasks'], args.warning))
+        else:
+            nagios_message(
+                'OK', "{0}/{1} pending tasks".format(result['pendingTasks'], args.critical))

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,8 @@ setup(
             "scriptworker = scriptworker.worker:main",
             "create_initial_gpg_homedirs = scriptworker.gpg:create_initial_gpg_homedirs",
             "rebuild_gpg_homedirs = scriptworker.gpg:rebuild_gpg_homedirs",
+            "nagios_check_pending_tasks = scriptworker.monitoring.nagios_pending_tasks:query_pending_task_count",
+            "nagios_check_file_ages = scriptworker.monitoring.nagios_file_age_check:run_file_age_checks",
         ],
     },
     zip_safe=False,


### PR DESCRIPTION
Intended initially for the signing scriptworkers,
but hopefully generic enough to be useful.

The entrypoint /usr/local/bin/nagios_check_file_ages can
report on files being too old or nonexistant.

/usr/local/bin/nagios_check_pending_tasks can alert if there
are too many pending tasks for that provisionerId and workerType

Nagios has its own directory for plugins, but python installs
these in /usr/local/bin - unsure at present whether this will
prevent nagios from using them, whether symlinks would be enough
if so.