### PR TITLE
stop uploading all the downloaded chain of trust artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Dockerfiles: one for general testing and one for gpg homedir testing, with readme updates
 - `flake8_docstrings` in tox.ini
+- log chain of trust verification more verbosely, since we no longer have real artifacts uploaded alongside
+
+### Changed
+- download cot artifacts into `work_dir/cot` instead of `artifact_dir/public/cot`, to avoid massive storage dups
+- `download_artifacts` now returns a list of full paths instead of relative paths. Since `upstreamArtifacts` contains the relative paths, this should be more helpful.
 
 ### Changed
 - check for a new gpg homedir before `run_loop`, because puppet will now use `rebuild_gpg_homedirs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - download cot artifacts into `work_dir/cot` instead of `artifact_dir/public/cot`, to avoid massive storage dups
 - `download_artifacts` now returns a list of full paths instead of relative paths. Since `upstreamArtifacts` contains the relative paths, this should be more helpful.
+- `contextual_log_handler` now takes a `logging.Formatter` kwarg rather than a log format string.
 
 ### Changed
 - check for a new gpg homedir before `run_loop`, because puppet will now use `rebuild_gpg_homedirs`

--- a/docs/chain_of_trust.md
+++ b/docs/chain_of_trust.md
@@ -71,7 +71,7 @@ The chain of trust is a second factor that isn't automatically compromised if sc
 - Download the chain of trust artifacts and verify their signatures
   - Using the above gpg homedirs
 - Download upstreamArtifacts and verify their shas against the chain of trust artifact shas
-  - These live in `$artifact_dir/public/cot/$upstream-task-id/$path` , so the script doesn't have to re-download and re-verify
+  - These live in `$work_dir/cot/$upstream-task-id/$path` , so the script doesn't have to re-download and re-verify
 - Verify the chain of trust
   - verify each task type:
     - [decision](https://github.com/mozilla-releng/scriptworker/blob/910c2056bf31c190a2c95c8f6435386dceb66083/scriptworker/cot/verify.py#L759)

--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -112,7 +112,7 @@ def get_log_fhs(context):
 
 @contextmanager
 def contextual_log_handler(context, path, log_obj=None, level=logging.DEBUG,
-                           fmt='%(asctime)s %(levelname)8s - %(message)s'):
+                           formatter=None):
     """Add a short-lived log with a contextmanager for cleanup.
 
     Args:
@@ -121,19 +121,22 @@ def contextual_log_handler(context, path, log_obj=None, level=logging.DEBUG,
         log_obj (logging.Logger): the log object to modify.  If None, use
             ``scriptworker.log.log``.  Defaults to None.
         level (int, optional): the logging level.  Defaults to logging.DEBUG.
-        fmt (str, optional): the logging format.  Defaults to '%(asctime)s %(levelname)8s - %(message)s'
+        formatter (logging.Formatter, optional): the logging formatter. If None,
+            defaults to ``logging.Formatter(fmt=fmt)``. Default is None.
 
     Yields:
         None: but cleans up the handler afterwards.
     """
     log_obj = log_obj or log
+    formatter = formatter or logging.Formatter(
+        fmt=context.config['log_fmt'],
+        datefmt=context.config['log_datefmt'],
+    )
     parent_path = os.path.dirname(path)
     makedirs(parent_path)
     contextual_handler = logging.FileHandler(path, encoding='utf-8')
     contextual_handler.setLevel(level)
-    contextual_handler.setFormatter(
-        logging.Formatter(fmt=fmt)
-    )
+    contextual_handler.setFormatter(formatter)
     log_obj.addHandler(contextual_handler)
     yield
     log_obj.removeHandler(contextual_handler)

--- a/scriptworker/task.py
+++ b/scriptworker/task.py
@@ -439,8 +439,7 @@ async def download_artifacts(context, file_urls, parent_dir=None, session=None,
             plus the decision taskId.  Defaults to None.
 
     Returns:
-        list: the relative paths to the files downloaded, relative to
-            ``parent_dir``.
+        list: the full paths to the files downloaded
 
     Raises:
         scriptworker.exceptions.DownloadError: on download failure after
@@ -457,7 +456,7 @@ async def download_artifacts(context, file_urls, parent_dir=None, session=None,
     for file_url in file_urls:
         rel_path = validate_artifact_url(valid_artifact_rules, valid_artifact_task_ids, file_url)
         abs_file_path = os.path.join(parent_dir, rel_path)
-        files.append(rel_path)
+        files.append(abs_file_path)
         tasks.append(
             asyncio.ensure_future(
                 retry_async(

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -438,6 +438,12 @@ async def test_build_task_dependencies(chain, mocker, event_loop):
 @pytest.mark.parametrize("raises", (True, False))
 @pytest.mark.asyncio
 async def test_download_cot(chain, mocker, raises, event_loop):
+    async def down(*args, **kwargs):
+        return ['x']
+
+    def sha(*args, **kwargs):
+        return "sha"
+
     m = mock.MagicMock()
     m.task_id = "x"
     m.cot_dir = "y"
@@ -448,7 +454,8 @@ async def test_download_cot(chain, mocker, raises, event_loop):
         with pytest.raises(CoTError):
             await cotverify.download_cot(chain)
     else:
-        mocker.patch.object(cotverify, 'download_artifacts', new=noop_async)
+        mocker.patch.object(cotverify, 'download_artifacts', new=down)
+        mocker.patch.object(cotverify, 'get_hash', new=sha)
         await cotverify.download_cot(chain)
 
 

--- a/scriptworker/test/test_task.py
+++ b/scriptworker/test/test_task.py
@@ -289,9 +289,6 @@ def test_download_artifacts(context, event_loop):
         os.path.join(context.config['work_dir'], "foo", "bar"),
         os.path.join(context.config['work_dir'], "baz"),
     ]
-    expected_result = [
-        "foo/bar", "baz"
-    ]
 
     async def foo(_, url, path, **kwargs):
         urls.append(url)
@@ -301,6 +298,6 @@ def test_download_artifacts(context, event_loop):
         task.download_artifacts(context, expected_urls, download_func=foo)
     )
 
-    assert sorted(result) == sorted(expected_result)
+    assert sorted(result) == sorted(expected_paths)
     assert sorted(paths) == sorted(expected_paths)
     assert sorted(urls) == sorted(expected_urls)


### PR DESCRIPTION
We have pointers to the existing artifacts in other tasks, and now the
log is more verbose around what we're doing.  I think we can make the
log more readable, but I think we have a good coverage of information at
least.

Fixes #35.