### PR TITLE
catch aiohttp exceptions during upload_artifacts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - updated all docstrings to pass `flake8_docstrings`
 - switched to a three-phase lockfile for gpg homedir creation to avoid race conditions (locked, ready, unlocked)
+- catch `aiohttp.errors.DisconnectedError` and `aiohttp.errors.ClientError` in `run_loop` during `upload_artifacts`
+- compare the built docker-image tarball hash against `imageArtifactHash`
 
 ### Removed
 - the `create_initial_gpg_homedirs` entry point has been removed in favor of `rebuild_gpg_homedirs`.

--- a/scriptworker/test/test_worker.py
+++ b/scriptworker/test/test_worker.py
@@ -158,6 +158,8 @@ def test_mocker_run_loop_noop(context, successful_queue, event_loop, mocker):
     'upload_artifacts', ScriptWorkerException, ScriptWorkerException.exit_code
 ), (
     'upload_artifacts', aiohttp.errors.DisconnectedError, STATUSES['resource-unavailable']
+), (
+    'upload_artifacts', aiohttp.errors.ClientError, STATUSES['resource-unavailable']
 )))
 def test_mocker_run_loop_exception(context, successful_queue, event_loop,
                                    mocker, func_to_raise, exc, expected):

--- a/scriptworker/test/test_worker.py
+++ b/scriptworker/test/test_worker.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 """Test scriptworker.worker
 """
+import aiohttp
 import arrow
 import asyncio
 from copy import deepcopy
@@ -12,6 +13,7 @@ import pytest
 import tempfile
 import shutil
 import sys
+from scriptworker.constants import STATUSES
 from scriptworker.exceptions import ScriptWorkerException
 import scriptworker.worker as worker
 from . import event_loop, noop_async, noop_sync, rw_context, successful_queue, tmpdir
@@ -150,9 +152,15 @@ def test_mocker_run_loop_noop(context, successful_queue, event_loop, mocker):
     assert status is None
 
 
-@pytest.mark.parametrize("func_to_raise", ['run_task', 'upload_artifacts'])
-def test_mocker_run_loop_exception(context, successful_queue,
-                                   event_loop, mocker, func_to_raise):
+@pytest.mark.parametrize("func_to_raise,exc,expected", ((
+    'run_task', ScriptWorkerException, ScriptWorkerException.exit_code
+), (
+    'upload_artifacts', ScriptWorkerException, ScriptWorkerException.exit_code
+), (
+    'upload_artifacts', aiohttp.errors.DisconnectedError, STATUSES['resource-unavailable']
+)))
+def test_mocker_run_loop_exception(context, successful_queue, event_loop,
+                                   mocker, func_to_raise, exc, expected):
     """Raise an exception within the run_loop try/excepts and make sure the
     status is changed
     """
@@ -161,8 +169,8 @@ def test_mocker_run_loop_exception(context, successful_queue,
     async def find_task(*args, **kwargs):
         return task
 
-    async def exc(*args, **kwargs):
-        raise ScriptWorkerException("foo")
+    async def fail(*args, **kwargs):
+        raise exc("foo")
 
     async def run_task(*args, **kwargs):
         return 0
@@ -171,14 +179,14 @@ def test_mocker_run_loop_exception(context, successful_queue,
     mocker.patch.object(worker, "find_task", new=find_task)
     mocker.patch.object(worker, "reclaim_task", new=noop_async)
     if func_to_raise == "run_task":
-        mocker.patch.object(worker, "run_task", new=exc)
+        mocker.patch.object(worker, "run_task", new=fail)
     else:
         mocker.patch.object(worker, "run_task", new=run_task)
     mocker.patch.object(worker, "generate_cot", new=noop_sync)
     if func_to_raise == "upload_artifacts":
-        mocker.patch.object(worker, "upload_artifacts", new=exc)
+        mocker.patch.object(worker, "upload_artifacts", new=fail)
     else:
         mocker.patch.object(worker, "upload_artifacts", new=noop_async)
     mocker.patch.object(worker, "complete_task", new=noop_async)
     status = event_loop.run_until_complete(worker.run_loop(context))
-    assert status == ScriptWorkerException.exit_code
+    assert status == expected

--- a/scriptworker/worker.py
+++ b/scriptworker/worker.py
@@ -12,6 +12,7 @@ import sys
 
 from scriptworker.poll import find_task, get_azure_urls, update_poll_task_urls
 from scriptworker.config import get_context_from_cmdln
+from scriptworker.constants import STATUSES
 from scriptworker.cot.generate import generate_cot
 from scriptworker.cot.verify import ChainOfTrust, verify_chain_of_trust
 from scriptworker.gpg import get_tmp_base_gpg_home_dir, is_lockfile_present, overwrite_gpg_home, rm_lockfile
@@ -65,6 +66,9 @@ async def run_loop(context, creds_key="credentials"):
             except ScriptWorkerException as e:
                 status = worst_level(status, e.exit_code)
                 log.error("Hit ScriptWorkerException: {}".format(str(e)))
+            except (aiohttp.errors.DisconnectedError, aiohttp.errors.ClientError) as e:
+                status = worst_level(status, STATUSES['resource-unavailable'])
+                log.error("Hit aiohttp error: {}".format(str(e)))
             await complete_task(context, status)
             cleanup(context)
             await asyncio.sleep(1)

--- a/scriptworker/worker.py
+++ b/scriptworker/worker.py
@@ -60,15 +60,15 @@ async def run_loop(context, creds_key="credentials"):
                 generate_cot(context)
             except ScriptWorkerException as e:
                 status = worst_level(status, e.exit_code)
-                log.error("Hit ScriptWorkerException: {}".format(str(e)))
+                log.error("Hit ScriptWorkerException: {}".format(e))
             try:
                 await upload_artifacts(context)
             except ScriptWorkerException as e:
                 status = worst_level(status, e.exit_code)
-                log.error("Hit ScriptWorkerException: {}".format(str(e)))
+                log.error("Hit ScriptWorkerException: {}".format(e))
             except (aiohttp.errors.DisconnectedError, aiohttp.errors.ClientError) as e:
                 status = worst_level(status, STATUSES['resource-unavailable'])
-                log.error("Hit aiohttp error: {}".format(str(e)))
+                log.error("Hit aiohttp error: {}".format(e))
             await complete_task(context, status)
             cleanup(context)
             await asyncio.sleep(1)


### PR DESCRIPTION
In #34 we're hitting an uncaught exception during `upload_artifacts`.
This patch catches it, logs the error, and marks the task as
`resource-unavailable`.

@JohanLorenzo @lundjordan sorry for all the review requests! I'm hoping that a lot of smaller reviews is easier than one big one.