### PR TITLE
Support beetmover and balrog in chain of trust verification

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -123,6 +123,8 @@ DEFAULT_CONFIG = frozendict({
 
     # scriptworker identification
     "scriptworker_worker_types": (
+        "balrogworker-v1",
+        "beetmoverworker-v1",
         "signing-linux-v1",
     ),
     "scriptworker_provisioners": (

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -59,6 +59,7 @@ DEFAULT_CONFIG = frozendict({
     "verify_chain_of_trust": False,  # TODO True
     "verify_cot_signature": False,
     "cot_job_type": "unknown",  # e.g., signing
+    "cot_product": "firefox",
 
     # Specify a default gpg home other than ~/.gnupg
     "gpg_home": None,
@@ -212,14 +213,25 @@ DEFAULT_CONFIG = frozendict({
         ],
     }, ),
 
-    # Scopes, restricted by task type and repo
+    # Map scopes to restricted-level
     'cot_restricted_scopes': frozendict({
-        'signing': {
-            # Which repos can do release signing?
+        'firefox': {
+            'project:releng:beetmover:release': 'release',
+            'project:releng:balrog:release': 'release',
+            'project:releng:signing:cert:release-signing': 'release',
+            'project:releng:balrog:nightly': 'nightly',
+            'project:releng:beetmover:nightly': 'nightly',
+            'project:releng:signing:cert:nightly-signing': 'nightly',
+        }
+    }),
+    # Map restricted-level to trees
+    'cot_restricted_trees': frozendict({
+        'firefox': {
+            # Which repos can perform release actions?
             # Allow aurora for staging betas.
             # XXX remove /projects/jamun when we no longer release firefox
             #     from it
-            'project:releng:signing:cert:release-signing': (
+            'release': (
                 "/releases/mozilla-aurora",
                 "/releases/mozilla-beta",
                 "/releases/mozilla-release",
@@ -232,7 +244,7 @@ DEFAULT_CONFIG = frozendict({
             #     tier1 and landed on mozilla-central
             # XXX remove /projects/jamun when we no longer release firefox
             #     from it
-            'project:releng:signing:cert:nightly-signing': (
+            'nightly': (
                 "/mozilla-central",
                 "/releases/mozilla-unified",
                 "/releases/mozilla-aurora",
@@ -244,7 +256,6 @@ DEFAULT_CONFIG = frozendict({
                 "/projects/date",
             ),
         },
-        # TODO other scriptworker instance types
     }),
 })
 

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -293,8 +293,9 @@ def get_valid_task_types():
     Returns:
         frozendict: maps the valid task types (e.g., signing) to their validation functions.
     """
-    # TODO support the rest of the task types... balrog, apkpush, beetmover, hgpush, etc.
     return frozendict({
+        'scriptworker': verify_scriptworker_task,
+        'beetmover': verify_beetmover_task,
         'build': verify_build_task,
         'l10n': verify_build_task,
         'decision': verify_decision_task,
@@ -925,6 +926,38 @@ async def verify_docker_image_task(chain, link):
     raise_on_errors(errors)
 
 
+# verify_balrog_task {{{1
+async def verify_balrog_task(chain, obj):
+    """Verify the balrog trust object.
+
+    Currently the only check is to make sure it was run on a scriptworker.
+
+    Args:
+        chain (ChainOfTrust): the chain we're operating on
+        obj (ChainOfTrust or LinkOfTrust): the trust object for the balrog task.
+
+    Raises:
+        CoTError: on error.
+    """
+    return await verify_scriptworker_task(chain, obj)
+
+
+# verify_beetmover_task {{{1
+async def verify_beetmover_task(chain, obj):
+    """Verify the beetmover trust object.
+
+    Currently the only check is to make sure it was run on a scriptworker.
+
+    Args:
+        chain (ChainOfTrust): the chain we're operating on
+        obj (ChainOfTrust or LinkOfTrust): the trust object for the beetmover task.
+
+    Raises:
+        CoTError: on error.
+    """
+    return await verify_scriptworker_task(chain, obj)
+
+
 # verify_signing_task {{{1
 async def verify_signing_task(chain, obj):
     """Verify the signing trust object.
@@ -934,11 +967,11 @@ async def verify_signing_task(chain, obj):
     Args:
         chain (ChainOfTrust): the chain we're operating on
         obj (ChainOfTrust or LinkOfTrust): the trust object for the signing task.
+
+    Raises:
+        CoTError: on error.
     """
-    errors = []
-    if obj.worker_impl != "scriptworker":
-        errors.append("{} {} must be run from scriptworker!".format(obj.name, obj.task_id))
-    raise_on_errors(errors)
+    return await verify_scriptworker_task(chain, obj)
 
 
 # check_num_tasks {{{1
@@ -1011,15 +1044,18 @@ async def verify_docker_worker_task(chain, link):
 
 # verify_scriptworker_task {{{1
 async def verify_scriptworker_task(chain, obj):
-    """Verify the scriptworker object.
+    """Verify the signing trust object.
 
-    Noop for now.
+    Currently the only check is to make sure it was run on a scriptworker.
 
     Args:
         chain (ChainOfTrust): the chain we're operating on
         obj (ChainOfTrust or LinkOfTrust): the trust object for the signing task.
     """
-    pass
+    errors = []
+    if obj.worker_impl != "scriptworker":
+        errors.append("{} {} must be run from scriptworker!".format(obj.name, obj.task_id))
+    raise_on_errors(errors)
 
 
 # verify_worker_impls {{{1
@@ -1205,6 +1241,8 @@ This is helpful in debugging chain of trust changes or issues.
 To use, first either set your taskcluster creds in your env http://bit.ly/2eDMa6N
 or in the CREDS_FILES http://bit.ly/2fVMu0A""")
     parser.add_argument('task_id', help='the task id to test')
+    parser.add_argument('--task-type', help='the task type to test',
+                        choices=["signing", "balrog", "beetmover"], required=True)
     parser.add_argument('--cleanup', help='clean up the temp dir afterwards',
                         dest='cleanup', action='store_true', default=False)
     opts = parser.parse_args(args)
@@ -1228,7 +1266,7 @@ or in the CREDS_FILES http://bit.ly/2fVMu0A""")
                 'base_gpg_home_dir': os.path.join(tmp, 'gpg'),
                 'verify_cot_signature': False,
             })
-            cot = ChainOfTrust(context, 'signing', task_id=opts.task_id)
+            cot = ChainOfTrust(context, opts.task_type, task_id=opts.task_id)
             loop.run_until_complete(verify_chain_of_trust(cot))
             log.info(pprint.pformat(cot.dependent_task_ids()))
             log.info("Cot task_id: {}".format(cot.task_id))

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -833,18 +833,22 @@ async def test_verify_docker_image_task_command(chain, docker_image_link):
         await cotverify.verify_docker_image_task(chain, docker_image_link)
 
 
-# verify_signing_task {{{1
+# verify_scriptworker_task {{{1
+@pytest.mark.parametrize("func", ["verify_balrog_task", "verify_beetmover_task",
+                                  "verify_signing_task", "verify_scriptworker_task"])
 @pytest.mark.asyncio
-async def test_verify_signing_task(chain, build_link):
+async def test_verify_scriptworker_task(chain, build_link, func):
     build_link.worker_impl = 'scriptworker'
-    await cotverify.verify_signing_task(chain, build_link)
+    await getattr(cotverify, func)(chain, build_link)
 
 
+@pytest.mark.parametrize("func", ["verify_balrog_task", "verify_beetmover_task",
+                                  "verify_signing_task", "verify_scriptworker_task"])
 @pytest.mark.asyncio
-async def test_verify_signing_task_worker_impl(chain, build_link):
+async def test_verify_scriptworker_task_worker_impl(chain, build_link, func):
     build_link.worker_impl = 'bad_impl'
     with pytest.raises(CoTError):
-        await cotverify.verify_signing_task(chain, build_link)
+        await getattr(cotverify, func)(chain, build_link)
 
 
 # check_num_tasks {{{1
@@ -873,12 +877,6 @@ async def test_verify_docker_worker_task(mocker):
     mocker.patch.object(cotverify, 'check_interactive_docker_worker', new=noop_sync)
     mocker.patch.object(cotverify, 'verify_docker_image_sha', new=noop_sync)
     await cotverify.verify_docker_worker_task(mock.MagicMock(), mock.MagicMock())
-
-
-# verify_scriptworker_task {{{1
-@pytest.mark.asyncio
-async def test_verify_scriptworker_task():
-    await cotverify.verify_scriptworker_task(mock.MagicMock(), mock.MagicMock())
 
 
 # verify_worker_impls {{{1
@@ -995,7 +993,7 @@ async def test_verify_chain_of_trust(chain, exc, mocker):
 
 
 # verify_cot_cmdln {{{1
-@pytest.mark.parametrize("args", (("x", "--cleanup"), ("x", )))
+@pytest.mark.parametrize("args", (("x", "--task-type", "signing", "--cleanup"), ("x", "--task-type", "balrog")))
 def test_verify_cot_cmdln(chain, args, tmpdir, mocker, event_loop):
     context = mock.MagicMock()
     context.queue = mock.MagicMock()

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -943,6 +943,13 @@ async def test_trace_back_to_firefox_tree_bad_repo(chain):
 
 
 @pytest.mark.asyncio
+async def test_trace_back_to_firefox_tree_bad_cot_product(chain):
+    chain.context.config['cot_product'] = 'invalid-product!!!111'
+    with pytest.raises(CoTError):
+        await cotverify.trace_back_to_firefox_tree(chain)
+
+
+@pytest.mark.asyncio
 async def test_trace_back_to_firefox_tree_unknown_repo(chain, decision_link,
                                                        build_link, docker_image_link):
     docker_image_link.decision_task_id = 'other'


### PR DESCRIPTION
@lundjordan @MihaiTabara you will need this PR to land before scriptworker can support beetmover and balrog.  I haven't tested everything all together, but hopefully this Just Works :)