### PR TITLE
Bug 1326436

### DIFF
--- a/docs/new_instance.md
+++ b/docs/new_instance.md
@@ -4,7 +4,7 @@ We don't yet have a scriptworker provisioner, so spinning up new instances of a 
 
 ## signing scriptworker
 ### gpg keypair
-Generate and sign a gpg keypair for cltsign@**fqdn**, per [these docs](chain_of_trust#adding-new-worker-gpg-keys).
+Generate and sign a gpg keypair for cltsign@**fqdn**, per [these docs](chain_of_trust.html#adding-new-worker-gpg-keys).
 
 The pubkey will need to land in the [cot-gpg-keys repo](https://github.com/mozilla-releng/cot-gpg-keys), in the `scriptworker/valid` directory.  The keypair will need to go into puppet hiera, as specified below.
 

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -103,6 +103,7 @@ DEFAULT_CONFIG = frozendict({
         "docker-image": [
             "sha256:74c5a18ce1768605ce9b1b5f009abac1ff11b55a007e2d03733cd6e95847c747",
             "sha256:d438d7818b6a47a0b1d49943ab12b5c504b65161806658e4c28f5f2aac821b9e",
+            "sha256:13b80a7a6b8e10c6096aba5a435529fbc99b405f56012e57cc6835facf4b40fb",
         ]
     }),
 


### PR DESCRIPTION
This PR adds the new docker-image sha, per [bug 1326436](https://bugzilla.mozilla.org/show_bug.cgi?id=1326436).

There's also a ride-along doc update (adding .html to the chain_of_trust link).

@lundjordan @JohanLorenzo if you have a moment :)