### PR TITLE
Enhance error message when creds are missing

### DIFF
--- a/scriptworker/config.py
+++ b/scriptworker/config.py
@@ -94,6 +94,11 @@ def check_config(config, path):
         list: the error messages found when validating the config.
     """
     messages = []
+
+    missing_keys = set(DEFAULT_CONFIG.keys()) - set(config.keys())
+    if missing_keys:
+        messages.append("Missing config keys {}!".format(missing_keys))
+
     for key, value in config.items():
         if key not in DEFAULT_CONFIG:
             messages.append("Unknown key {} in {}!".format(key, path))

--- a/scriptworker/test/test_config.py
+++ b/scriptworker/test/test_config.py
@@ -62,7 +62,7 @@ def test_check_config_invalid_key(t_config):
     assert "Unknown key" in "\n".join(messages)
 
 
-def test_check_config_missing_key(t_config):
+def test_check_config_none_key(t_config):
     t_config = _fill_missing_values(t_config)
 
     # The current implementation of create_config() doesn't delete t_config['credentials']
@@ -70,6 +70,13 @@ def test_check_config_missing_key(t_config):
     t_config['credentials'] = None
     messages = config.check_config(t_config, "test_path")
     assert "credentials needs to be defined!" in "\n".join(messages)
+
+def test_check_config_missing_key(t_config):
+    t_config = _fill_missing_values(t_config)
+
+    del t_config['work_dir']
+    messages = config.check_config(t_config, "test_path")
+    assert "Missing config keys {'work_dir'}" in "\n".join(messages)
 
 
 def _fill_missing_values(config):

--- a/scriptworker/test/test_config.py
+++ b/scriptworker/test/test_config.py
@@ -62,6 +62,23 @@ def test_check_config_invalid_key(t_config):
     assert "Unknown key" in "\n".join(messages)
 
 
+def test_check_config_missing_key(t_config):
+    t_config = _fill_missing_values(t_config)
+
+    # The current implementation of create_config() doesn't delete t_config['credentials']
+    # if no secrets are present in any file.
+    t_config['credentials'] = None
+    messages = config.check_config(t_config, "test_path")
+    assert "credentials needs to be defined!" in "\n".join(messages)
+
+
+def _fill_missing_values(config):
+    return {
+        key: 'filled_in' if value == '...' else value
+        for key, value in config.items()
+    }
+
+
 def test_check_config_invalid_type(t_config):
     t_config['log_dir'] = tuple(t_config['log_dir'])
     messages = config.check_config(t_config, "test_path")
@@ -82,9 +99,7 @@ def test_check_config_invalid_ids(params, t_config):
 
 
 def test_check_config_good(t_config):
-    for key, value in t_config.items():
-        if value == "...":
-            t_config[key] = "filled_in"
+    t_config = _fill_missing_values(t_config)
     messages = config.check_config(t_config, "test_path")
     assert messages == []
 


### PR DESCRIPTION
If you don't specify credentials (either because you forgot, or because you didn't paste things correctly in `secrets.json`), you end up with: `scriptworker.yaml credentials: type <class 'NoneType'> is not <class 'frozendict.frozendict'>!`

This patch replaces with that one instead:
```
scriptworker.yaml credentials needs to be defined!
```