### PR TITLE
Git tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+- `git_key_repo_tag` config option
+- `verify_signed_tag`, which verifies the tag's signature and makes sure we're updated to it.
+
+### Changed
+- `get_git_revision` now takes a `ref` kwarg; it finds the revision for that ref (e.g., tag, branch).
+- `update_signed_git_repo` `revision` kwarg is now named `ref`.  It also verifies and updates to the signed git tag instead of `ref`.
+- `build_gpg_homedirs_from_repo` now uses `verify_signed_tag` instead of `verify_signed_git_commit`
+
+### Removed
+- `verify_signed_git_commit_output`
+- `verify_signed_git_commit`
+
 ## [1.0.0b4] - 2016-12-19
 ### Added
 - beetmover and balrog scriptworker support in chain of trust verification

--- a/scriptworker.yaml.tmpl
+++ b/scriptworker.yaml.tmpl
@@ -78,9 +78,10 @@ gpg_lockfile: "/tmp/gpg_homedir.lock"
 # the git_key_repo_url is cloned into git_key_repo_dir.
 git_key_repo_dir: "/tmp/key_repo"
 
-# Uncomment and edit to override the default url.  This shouldn't be necessary unless you're
-# testing changes to the chain of trust.
+# Uncomment and edit to override the default url and/or tag name.  This shouldn't be necessary
+# unless you're testing changes to the chain of trust.
 # git_key_repo_url: "https://github.com/mozilla-releng/cot-gpg-keys.git"
+# git_key_repo_tag: "production"
 
 # this directory holds pubkeys that are allowed to sign git commits in the git_key_repo_url
 git_commit_signing_pubkey_dir: "/tmp/valid_git_fingerprints/"

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -78,6 +78,7 @@ DEFAULT_CONFIG = frozendict({
     "gpg_lockfile": os.path.join(os.getcwd(), "gpg_homedir.lock"),
     "git_key_repo_dir": "...",
     "git_key_repo_url": "https://github.com/mozilla-releng/cot-gpg-keys.git",
+    "git_key_repo_tag": "production",
     "last_good_git_revision_file": os.path.join(os.getcwd(), "git_revision"),
     "pubkey_path": "...",
     "privkey_path": "...",

--- a/scriptworker/gpg.py
+++ b/scriptworker/gpg.py
@@ -1141,7 +1141,7 @@ async def get_git_revision(path, ref="HEAD",
     """Get the git revision of path.
 
     Args:
-        path (str): the path to run ``git rev-parse REF`` in.
+        path (str): the path to run ``git log -n1 --format=format:%H REF`` in.
         ref (str, optional): the ref to find the revision for.  Defaults to "HEAD"
 
     Returns:
@@ -1151,7 +1151,7 @@ async def get_git_revision(path, ref="HEAD",
         ScriptWorkerRetryException: on failure.
     """
     proc = await exec_function(
-        'git', "rev-parse", "HEAD", cwd=path,
+        'git', "log", "-n1", "--format=format:%H", ref, cwd=path,
         stdout=PIPE, stderr=DEVNULL, stdin=DEVNULL, close_fds=True,
     )
     revision, err = await proc.communicate()

--- a/scriptworker/gpg.py
+++ b/scriptworker/gpg.py
@@ -1186,6 +1186,7 @@ async def update_signed_git_repo(context, repo="origin", ref="master",
     tag = context.config['git_key_repo_tag']
 
     async def _run_git_cmd(cmd):
+        log.info("Running {} in {}".format(cmd, path))
         proc = await exec_function(
             *cmd, cwd=path,
             stdout=PIPE, stderr=STDOUT, stdin=DEVNULL, close_fds=True,

--- a/scriptworker/gpg.py
+++ b/scriptworker/gpg.py
@@ -1355,6 +1355,8 @@ def _update_git_and_rebuild_homedirs(context, basedir=None):
         log.info("Writing last_good_git_revision...")
         write_last_good_git_revision(context, new_revision)
         return new_revision
+    else:
+        log.info("Git revision {} is unchanged.".format(new_revision))
 
 
 def get_tmp_base_gpg_home_dir(context):

--- a/scriptworker/gpg.py
+++ b/scriptworker/gpg.py
@@ -1201,9 +1201,9 @@ async def update_signed_git_repo(context, repo="origin", ref="master",
     for cmd in (
         ["git", "checkout", ref],
         ["git", "pull", "--ff-only", "--tags", repo],
+        ["git", "checkout", tag],
     ):
         await _run_git_cmd(cmd)
-    await _run_git_cmd(["git", "checkout", tag])
     await verify_signed_tag(context)
     revision = await get_git_revision(path, tag)
     return revision

--- a/scriptworker/test/test_gpg.py
+++ b/scriptworker/test/test_gpg.py
@@ -83,88 +83,6 @@ KEYS_AND_FINGERPRINTS = ((
     os.path.join(GPG_HOME, "keys", "unknown@example.com"),
 ))
 
-VERIFY_GIT_OUTPUT_BAD_PARAMS = (
-    "Author: Aki Sasaki <aki@escapewindow.com>\nDate:   Mon Sep 19 21:50:35 2016 -0700\n\n    add another check + small fixes + comments",
-
-    """commit 6efb4ebe8900ad1920f6eaaf64b615fe6e6e839a
-gpg: Signature made Mon Sep 19 21:50:53 2016 PDT
-gpg:                using RSA key FC829B7FFAA9AC38
-gpg: Good signature from "Aki Sasaki (2016.09.16) <aki@escapewindow.com>" [unknown]
-gpg:                 aka "Aki Sasaki (2016.09.16) <aki@mozilla.com>" [unknown]
-gpg:                 aka "Aki Sasaki (2016.09.16) <asasaki@mozilla.com>" [unknown]
-gpg:                 aka "[jpeg image of size 5283]" [unknown]
-gpg: WARNING: This key is not certified with a trusted signature!
-gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: 83A4 B550 BC68 2F0B 0601  57B0 4654 904B B484 B6B2
-     Subkey fingerprint: CC62 C097 98FD EFBB 4CC9  4D9C FC82 9B7F FAA9 AC38
-Author: Aki Sasaki <aki@escapewindow.com>
-Date:   Mon Sep 19 21:50:35 2016 -0700
-
-    add another check + small fixes + comments
-""",
-
-    """commit 6efb4ebe8900ad1920f6eaaf64b615fe6e6e839a
-gpg: directory `/Users/asasaki/.gnupg' created
-gpg: new configuration file `/Users/asasaki/.gnupg/gpg.conf' created
-gpg: WARNING: options in `/Users/asasaki/.gnupg/gpg.conf' are not yet active during this run
-gpg: keyring `/Users/asasaki/.gnupg/pubring.gpg' created
-gpg: Signature made Mon Sep 19 21:50:53 2016 PDT
-gpg:                using RSA key FC829B7FFAA9AC38
-gpg: Can't check signature: No public key
-Author: Aki Sasaki <aki@escapewindow.com>
-Date:   Mon Sep 19 21:50:35 2016 -0700
-
-    add another check + small fixes + comments
-""",
-)
-
-VERIFY_GIT_OUTPUT_GOOD_PARAMS = (
-    """commit 6efb4ebe8900ad1920f6eaaf64b615fe6e6e839a
-gpg: Signature made Mon Sep 19 21:50:53 2016 PDT
-gpg:                using RSA key FC829B7FFAA9AC38
-gpg: checking the trustdb
-gpg: 3 marginal(s) needed, 1 complete(s) needed, PGP trust model
-gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
-gpg: next trustdb check due at 2018-09-17
-gpg: Good signature from "Aki Sasaki (2016.09.16) <aki@escapewindow.com>" [ultimate]
-gpg:                 aka "Aki Sasaki (2016.09.16) <aki@mozilla.com>" [ultimate]
-gpg:                 aka "Aki Sasaki (2016.09.16) <asasaki@mozilla.com>" [ultimate]
-gpg:                 aka "[jpeg image of size 5283]" [ultimate]
-Author: Aki Sasaki <aki@escapewindow.com>
-Date:   Mon Sep 19 21:50:35 2016 -0700
-
-    add another check + small fixes + comments
-""",
-    """commit 6efb4ebe8900ad1920f6eaaf64b615fe6e6e839a
-gpg: Signature made Mon Sep 19 21:50:53 2016 PDT
-gpg:                using RSA key FC829B7FFAA9AC38
-gpg: checking the trustdb
-gpg: 3 marginal(s) needed, 1 complete(s) needed, PGP trust model
-gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
-gpg: next trustdb check due at 2018-09-17
-gpg: Good signature from "Aki Sasaki (2016.09.16) <aki@escapewindow.com>" [trusted]
-gpg:                 aka "Aki Sasaki (2016.09.16) <aki@mozilla.com>" [trusted]
-gpg:                 aka "Aki Sasaki (2016.09.16) <asasaki@mozilla.com>" [trusted]
-gpg:                 aka "[jpeg image of size 5283]" [trusted]
-Author: Aki Sasaki <aki@escapewindow.com>
-Date:   Mon Sep 19 21:50:35 2016 -0700
-
-    add another check + small fixes + comments
-""",
-    """commit 02dc29251021519ebac4508545477a7b23efea49
-gpg: Signature made Tue Sep 20 04:22:57 2016 UTC
-gpg:                using RSA key 0xFC829B7FFAA9AC38
-gpg: Good signature from "Aki Sasaki (2016.09.16) <aki@escapewindow.com>"
-gpg:                 aka "Aki Sasaki (2016.09.16) <aki@mozilla.com>"
-gpg:                 aka "Aki Sasaki (2016.09.16) <asasaki@mozilla.com>"
-gpg:                 aka "[jpeg image of size 5283]"
-Author: Aki Sasaki <aki@escapewindow.com>
-Date:   Mon Sep 19 21:22:40 2016 -0700
-
-    add travis tests for commit signatures.
-""",
-)
-
 
 def versionless(ascii_key):
     """Strip the gpg version out of a key, to aid in comparison
@@ -671,18 +589,6 @@ def test_rebuild_gpg_home_signed(context, trusted_email, tmpdir):
     assert messages == []
 
 
-# verify_signed_git_commit_output {{{1
-@pytest.mark.parametrize("output", VERIFY_GIT_OUTPUT_GOOD_PARAMS)
-def test_verify_signed_git_commit_output(output):
-    sgpg.verify_signed_git_commit_output(output)
-
-
-@pytest.mark.parametrize("output", VERIFY_GIT_OUTPUT_BAD_PARAMS)
-def test_verify_signed_git_commit_output_exception(output):
-    with pytest.raises(ScriptWorkerGPGException):
-        sgpg.verify_signed_git_commit_output(output)
-
-
 # get_git_revision {{{1
 @pytest.mark.asyncio
 async def test_get_git_revision():
@@ -737,6 +643,7 @@ async def test_update_signed_git_repo(context, mocker, result1, result2, expecte
         return value
 
     mocker.patch.object(sgpg, "get_git_revision", new=fake_revision)
+    mocker.patch.object(sgpg, "verify_signed_tag", new=noop_async)
     if return_value:
         with pytest.raises(ScriptWorkerRetryException):
             await sgpg.update_signed_git_repo(
@@ -747,25 +654,30 @@ async def test_update_signed_git_repo(context, mocker, result1, result2, expecte
         assert result == expected
 
 
-# verify_signed_git_commit {{{1
+# verify_signed_tag {{{1
+@pytest.mark.parametrize("valid_signed,head_rev,tag_rev,raises", (
+    [False, "foo", "foo", True],
+    [True, "foo", "foo", False],
+    [True, "foo", "bar", True],
+))
 @pytest.mark.asyncio
-async def test_verify_signed_git_commit(context, mocker):
-    output = [b'onetwothree', b'onetwothree']
+async def test_verify_signed_tag(context, mocker, valid_signed, head_rev, tag_rev, raises):
 
-    async def fake_readline():
-        if output:
-            return output.pop(0)
+    async def fake_revision(path, ref):
+        if ref == "HEAD":
+            return head_rev
+        return tag_rev
 
-    stdout = mock.MagicMock()
-    stdout.readline = fake_readline
+    def fake_exec(*args, **kwargs):
+        if not valid_signed:
+            raise subprocess.CalledProcessError(1, args)
 
-    async def fake_exec(*args, **kwargs):
-        m = mock.MagicMock()
-        m.stdout = stdout
-        return m
-
-    mocker.patch.object(sgpg, "verify_signed_git_commit_output", new=noop_sync)
-    await sgpg.verify_signed_git_commit(context, exec_function=fake_exec)
+    mocker.patch.object(sgpg, "get_git_revision", new=fake_revision)
+    if raises:
+        with pytest.raises(ScriptWorkerGPGException):
+            await sgpg.verify_signed_tag(context, exec_function=fake_exec)
+    else:
+        await sgpg.verify_signed_tag(context, exec_function=fake_exec)
 
 
 # build_gpg_homedirs_from_repo {{{1
@@ -806,7 +718,7 @@ def test_rebuild_gpg_homedirs(context, mocker, event_loop, new_rev_found):
     mocker.patch.object(sgpg, "retry_async", new=new_revision)
     mocker.patch.object(sgpg, "update_ownertrust", new=noop_sync)
     mocker.patch.object(sgpg, "check_ownertrust", new=noop_sync)
-    mocker.patch.object(sgpg, "verify_signed_git_commit", new=noop_async)
+    mocker.patch.object(sgpg, "verify_signed_tag", new=noop_async)
     mocker.patch.object(sgpg, "overwrite_gpg_home", new=noop_sync)
     mocker.patch.object(sgpg, "get_last_good_git_revision", new=noop_sync)
     mocker.patch.object(sgpg, "build_gpg_homedirs_from_repo", new=noop_sync)
@@ -829,11 +741,10 @@ def test_rebuild_gpg_homedirs_exception(context, mocker, event_loop, nuke_dir):
     mocker.patch.object(sgpg, "rebuild_gpg_home_signed", new=die_sync)
     mocker.patch.object(sgpg, "retry_async", new=noop_async)
     mocker.patch.object(sgpg, "update_ownertrust", new=noop_sync)
-    mocker.patch.object(sgpg, "verify_signed_git_commit", new=noop_async)
+    mocker.patch.object(sgpg, "verify_signed_tag", new=noop_async)
     mocker.patch.object(sgpg, "overwrite_gpg_home", new=noop_sync)
     mocker.patch.object(sgpg, "update_signed_git_repo", new=noop_async)
     mocker.patch.object(sgpg, "build_gpg_homedirs_from_repo", new=noop_sync)
-
 
     with pytest.raises(SystemExit):
         sgpg.rebuild_gpg_homedirs()


### PR DESCRIPTION
@JohanLorenzo do you have some headspace for this review?

I'm basically moving from verifying the signature of the git commit to verifying the signature of the `production` tag.

I've run through testing this already; the following is only if you want to run tests yourself :)
**If you don't want to run the tests yourself, you can ignore the below.**

-----

If you want to test, there's the [dockerfile](https://github.com/escapewindow/scriptworker/blob/git-tags/docker/Dockerfile.gnupg) that you can use [like this](https://github.com/escapewindow/scriptworker/blob/git-tags/README.rst#gpg-homedir-testing).

Here are some specific steps for testing the git tag changes:

* create a github fork of https://github.com/mozilla-releng/cot-gpg-keys and clone it
* make sure to follow the [signing git commits docs](https://github.com/mozilla-releng/cot-gpg-keys#signing-git-commits) if you haven't already
* tag the first revision with a gpg signature:
```
    git tag -f -s -m "production" production 5603b6e937db483f4c36625ce52be95d165ace5b
    git push -f --tags
```
* clone my `git-tags` branch
* edit the dockerfile to [clone your fork](https://github.com/escapewindow/scriptworker/blob/git-tags/docker/Dockerfile.gnupg#L22) and [populate /data/git_pubkeys/ with your pubkey](https://github.com/escapewindow/scriptworker/blob/git-tags/docker/Dockerfile.gnupg#L23)
* build the docker image:
```
docker build -t scriptworker-gpg . && docker run -i scriptworker-gpg bash -il
```
* build the gpg homedirs:
```
    rebuild_gpg_homedirs scriptworker.yaml
    # this will create /data/gpg.tmp and /data/gpg_homedir.lock
    mv gpg.tmp gpg
    rm gpg_homedir.lock
```

A second run of `rebuild_gpg_homedirs` shouldn't rebuild `/data/gpg.tmp`.

In a separate window, tag a different revision of `cot-gpg-keys` (don't leave the docker image shell; you'll want it for the next step):
```
git tag -f -s -m "production" production 02dc29251021519ebac4508545477a7b23efea49
git push -f --tags
```

The next run of `rebuild_gpg_homedirs` should create a new `/data/gpg.tmp` and `/data/gpg_homedir.lock`.

And finally, if you don't sign the tag (replace the `-s` with a `-a`), you should hit an exception when you run `rebuild_gpg_homedirs`.