### PR TITLE
Delete cancelled or claimed tasks from azure queue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- delete azure queue entries on status code 409 (already claimed or cancelled).  This allows us to clean up cancelled tasks from the queue, speeding up future polling.
+- more retries and catches in `find_task`, making it more robust.
+
 ## [1.0.0b6] - 2017-01-12
 ### Fixed
 - balrog tasks are now verifiable in chain of trust.

--- a/scriptworker/poll.py
+++ b/scriptworker/poll.py
@@ -14,8 +14,8 @@ import time
 import urllib.parse
 
 import taskcluster.exceptions
-from scriptworker.exceptions import ScriptWorkerException
-from scriptworker.utils import datestring_to_timestamp, load_json
+from scriptworker.exceptions import ScriptWorkerException, ScriptWorkerRetryException
+from scriptworker.utils import datestring_to_timestamp, load_json, retry_async
 
 log = logging.getLogger(__name__)
 
@@ -83,9 +83,15 @@ async def claim_task(context, taskId, runId):
         result = await context.queue.claimTask(taskId, runId, payload)
         return result
     except taskcluster.exceptions.TaskclusterFailure as exc:
-        # TODO 409 is expected.  Not sure if we should ignore other errors?
         log.debug("Got %s" % exc)
-        return None
+        if hasattr(exc, 'status_code') and exc.status_code == 409:
+            # 409 means we found a task that's claimed by another worker
+            # or cancelled.  Let's return None and delete it from Azure
+            # so we don't get a backlog of bogus tasks in the queue.
+            log.debug("Got %s" % exc)
+            return None
+        else:
+            raise ScriptWorkerRetryException(str(exc))
 
 
 def get_azure_urls(context):
@@ -121,15 +127,33 @@ async def find_task(context, poll_url, delete_url, request_function):
 
     Returns:
         dict: the claimTask json
+
+    Raises:
+        ScriptWorkerException: on failure of request_function
     """
+    # this can raise a ScriptWorkerException on failure
     xml = await request_function(context, poll_url)
     for message_info in parse_azure_xml(xml):
-        task = await claim_task(context, message_info['task_info']['taskId'], message_info['task_info']['runId'])
-        if task is not None:
-            log.info("Found task! Deleting from azure...")
-            delete_url = delete_url.replace("{{", "{").replace("}}", "}").format(**message_info)
+        try:
+            task = await retry_async(
+                claim_task,
+                retry_exceptions=(ScriptWorkerRetryException, ),
+                args=(
+                    context, message_info['task_info']['taskId'],
+                    message_info['task_info']['runId']
+                )
+            )
+        except ScriptWorkerRetryException:
+            continue
+        log.debug("Deleting from azure...")
+        delete_url = delete_url.replace("{{", "{").replace("}}", "}").format(**message_info)
+        try:
             response = await request_function(context, delete_url, method='delete', good=[200, 204])
             log.debug(response)
+        except ScriptWorkerException as exc:
+            log.error("Unable to delete from Azure: {}".format(exc))
+            pass
+        if task is not None:
             return task
 
 

--- a/scriptworker/test/__init__.py
+++ b/scriptworker/test/__init__.py
@@ -106,7 +106,7 @@ class UnsuccessfulQueue(object):
     status = 409
 
     async def claimTask(self, *args, **kwargs):
-        raise taskcluster.exceptions.TaskclusterFailure("foo")
+        raise taskcluster.exceptions.TaskclusterRestFailure("foo", None, status_code=self.status)
 
     async def reportCompleted(self, *args, **kwargs):
         raise taskcluster.exceptions.TaskclusterRestFailure("foo", None, status_code=self.status)

--- a/scriptworker/test/test_poll.py
+++ b/scriptworker/test/test_poll.py
@@ -6,6 +6,7 @@ import arrow
 from copy import deepcopy
 import os
 import pytest
+from scriptworker.exceptions import ScriptWorkerRetryException
 import scriptworker.poll as poll
 from . import rw_context, event_loop, successful_queue, unsuccessful_queue
 
@@ -44,7 +45,7 @@ def azure_xml():
     return xml
 
 
-# tests {{{1
+# parse_azure_xml {{{1
 def test_parse_azure_xml(azure_xml):
     results = [{
         "messageId": "fdfc7989-b048-4ea8-bd33-69f63b83ba54",
@@ -69,6 +70,7 @@ def test_parse_azure_xml(azure_xml):
         assert message == results[count]
 
 
+# claim_task {{{1
 def test_successful_claim_task(context, successful_queue, event_loop):
     context.queue = successful_queue
     result = event_loop.run_until_complete(
@@ -77,14 +79,28 @@ def test_successful_claim_task(context, successful_queue, event_loop):
     assert result == successful_queue.result
 
 
-def test_unsuccessful_claim_task(context, unsuccessful_queue, event_loop):
+@pytest.mark.parametrize("error_code,raises", ((409, False), (500, True)))
+def test_unsuccessful_claim_task(context, unsuccessful_queue, event_loop,
+                                 error_code, raises):
+    """claim_task with a non-successful result.
+
+    On 409, the task has already been claimed or cancelled, but we should
+    delete it from the Azure queue.  We should get None.
+
+    On other errors, ``claim_task`` should raise ScriptWorkerRetryException
+    so we can retry.
+    """
+    unsuccessful_queue.status = error_code
     context.queue = unsuccessful_queue
-    result = event_loop.run_until_complete(
-        poll.claim_task(context, 1, 2)
-    )
-    assert result is None
+    if raises:
+        with pytest.raises(ScriptWorkerRetryException):
+            event_loop.run_until_complete(poll.claim_task(context, 1, 2))
+    else:
+        result = event_loop.run_until_complete(poll.claim_task(context, 1, 2))
+        assert result is None
 
 
+# update_poll_task_urls {{{1
 def test_update_expired_poll_task_urls(context, event_loop):
     context.poll_task_urls['expires'] = "2016-04-16T03:46:24.958Z"
     event_loop.run_until_complete(
@@ -111,6 +127,7 @@ def test_update_empty_poll_task_urls(context, event_loop):
     assert context.poll_task_urls == ((), {})
 
 
+# get_azure_urls {{{1
 def test_get_azure_urls(context):
     count = 0
     for poll_url, delete_url in poll.get_azure_urls(context):
@@ -119,6 +136,7 @@ def test_get_azure_urls(context):
         count += 1
 
 
+# find_task {{{1
 def test_successful_find_task(context, successful_queue, event_loop):
     context.queue = successful_queue
     result = event_loop.run_until_complete(
@@ -127,9 +145,28 @@ def test_successful_find_task(context, successful_queue, event_loop):
     assert result == "yay"
 
 
-def test_unsuccessful_find_task(context, unsuccessful_queue, event_loop):
+@pytest.mark.parametrize("raises", (True, False))
+def test_unsuccessful_find_task(context, unsuccessful_queue, event_loop, mocker, raises):
+    counters = {
+        "claim_task": 0,
+    }
+
+    # Raise the first time; return None the second
+    async def claim(*args, **kwargs):
+        if counters['claim_task']:
+            return None
+        counters['claim_task'] = counters['claim_task'] + 1
+        raise ScriptWorkerRetryException("died in claim")
+
+    async def req(_, url, **kwargs):
+        if url == "poll":
+            return await fake_request()
+        if raises:
+            raise ScriptWorkerRetryException("died in req")
+
+    mocker.patch.object(poll, 'retry_async', new=claim)
     context.queue = unsuccessful_queue
     result = event_loop.run_until_complete(
-        poll.find_task(context, "poll", "delete", fake_request)
+        poll.find_task(context, "poll", "delete", req)
     )
     assert result is None


### PR DESCRIPTION
While testing the nightly migration on the `date` branch, we noticed
scriptworker was slogging through a lot of tasks that were "already
claimed by another worker".  These turned out to be cancelled tasks, and
they stayed in the Azure queue because we didn't delete them.

This patch deletes those tasks from the Azure queue on status code 409.
It also adds retries and catches in `find_task`, making it more robust.
This is already running on beetmoverworker-1, and we've cleared out a
backlog of cancelled tasks from the queue because of it.

This patch fixes #55.