### PR TITLE
Use only one log file (live_backing.log)

### DIFF
--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -79,35 +79,33 @@ async def pipe_to_log(pipe, filehandles=(), level=logging.INFO):
             break
 
 
-def get_log_filenames(context):
+def get_log_filename(context):
     """Helper function to get the task log/error file paths.
 
     Args:
         context (scriptworker.context.Context): the scriptworker context.
 
     Returns:
-        tuple: log file path, error log file path
+        string: log file path
     """
-    log_file = os.path.join(context.config['task_log_dir'], 'task_output.log')
-    error_file = os.path.join(context.config['task_log_dir'], 'task_error.log')
-    return log_file, error_file
+    # XXX Even though our logs aren't live, Treeherder looks for live_backing.log to show errors in failures summary
+    return os.path.join(context.config['task_log_dir'], 'live_backing.log')
 
 
 @contextmanager
-def get_log_fhs(context):
+def get_log_filehandle(context):
     """Helper contextmanager function to open the log and error filehandles.
 
     Args:
         context (scriptworker.context.Context): the scriptworker context.
 
     Yields:
-        tuple: log filehandle, error log filehandle
+        log filehandle
     """
-    log_file, error_file = get_log_filenames(context)
+    log_file_name = get_log_filename(context)
     makedirs(context.config['task_log_dir'])
-    with open(log_file, "w", encoding="utf-8") as log_fh:
-        with open(error_file, "w", encoding="utf-8") as error_fh:
-            yield (log_fh, error_fh)
+    with open(log_file_name, "w", encoding="utf-8") as filehandle:
+        yield filehandle
 
 
 @contextmanager

--- a/scriptworker/task.py
+++ b/scriptworker/task.py
@@ -23,7 +23,7 @@ import taskcluster.exceptions
 from scriptworker.client import validate_artifact_url
 from scriptworker.constants import REVERSED_STATUSES
 from scriptworker.exceptions import ScriptWorkerRetryException
-from scriptworker.log import get_log_fhs, pipe_to_log
+from scriptworker.log import get_log_filehandle, pipe_to_log
 from scriptworker.utils import filepaths_in_dir, raise_future_exceptions, retry_async, download_file
 
 log = logging.getLogger(__name__)
@@ -118,14 +118,14 @@ async def run_task(context):
     loop.call_later(context.config['task_max_timeout'], max_timeout, context, context.proc, context.config['task_max_timeout'])
 
     tasks = []
-    with get_log_fhs(context) as (log_fh, error_fh):
-        tasks.append(pipe_to_log(context.proc.stderr, filehandles=[log_fh, error_fh]))
-        tasks.append(pipe_to_log(context.proc.stdout, filehandles=[log_fh]))
+    with get_log_filehandle(context) as log_filehandle:
+        tasks.append(pipe_to_log(context.proc.stderr, filehandles=[log_filehandle]))
+        tasks.append(pipe_to_log(context.proc.stdout, filehandles=[log_filehandle]))
         await asyncio.wait(tasks)
         exitcode = await context.proc.wait()
         status_line = "exit code: {}".format(exitcode)
         log.info(status_line)
-        print(status_line, file=log_fh)
+        print(status_line, file=log_filehandle)
 
     context.proc = None
     return exitcode

--- a/scriptworker/test/test_task.py
+++ b/scriptworker/test/test_task.py
@@ -92,9 +92,8 @@ def test_run_task(context, event_loop):
     status = event_loop.run_until_complete(
         task.run_task(context)
     )
-    log_file, error_file = log.get_log_filenames(context)
+    log_file = log.get_log_filename(context)
     assert read(log_file) in ("bar\nfoo\nexit code: 1\n", "foo\nbar\nexit code: 1\n")
-    assert read(error_file) == "bar\n"
     assert status == 1
 
 


### PR DESCRIPTION
Spin off that came out of [this discussion in #53](https://github.com/mozilla-releng/scriptworker/pull/53#discussion_r95844412). I split the changes in a new PR in order to make the review simpler.

PR also tested manually with https://tools.taskcluster.net/task-inspector/#ZXKOTGt1Qq6rUmPFDKfDmw/0 