### PR TITLE
support pushapk in chain of trust

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -125,6 +125,7 @@ DEFAULT_CONFIG = frozendict({
 
     # scriptworker identification
     "scriptworker_worker_types": (
+        "pushapk-v1",
         "balrogworker-v1",
         "beetmoverworker-v1",
         "signing-linux-v1",
@@ -218,11 +219,13 @@ DEFAULT_CONFIG = frozendict({
     # Map scopes to restricted-level
     'cot_restricted_scopes': frozendict({
         'firefox': {
-            'project:releng:beetmover:release': 'release',
             'project:releng:balrog:release': 'release',
+            'project:releng:beetmover:release': 'release',
+            'project:releng:pushapk:release': 'release',
             'project:releng:signing:cert:release-signing': 'release',
             'project:releng:balrog:nightly': 'nightly',
             'project:releng:beetmover:nightly': 'nightly',
+            'project:releng:pushapk:nightly': 'nightly',
             'project:releng:signing:cert:nightly-signing': 'nightly',
         }
     }),

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -301,6 +301,7 @@ def get_valid_task_types():
         'l10n': verify_build_task,
         'decision': verify_decision_task,
         'docker-image': verify_docker_image_task,
+        'pushapk': verify_pushapk_task,
         'signing': verify_signing_task,
     })
 
@@ -952,6 +953,22 @@ async def verify_beetmover_task(chain, obj):
     Args:
         chain (ChainOfTrust): the chain we're operating on
         obj (ChainOfTrust or LinkOfTrust): the trust object for the beetmover task.
+
+    Raises:
+        CoTError: on error.
+    """
+    return await verify_scriptworker_task(chain, obj)
+
+
+# verify_pushapk_task {{{1
+async def verify_pushapk_task(chain, obj):
+    """Verify the pushapk trust object.
+
+    Currently the only check is to make sure it was run on a scriptworker.
+
+    Args:
+        chain (ChainOfTrust): the chain we're operating on
+        obj (ChainOfTrust or LinkOfTrust): the trust object for the pushapk task.
 
     Raises:
         CoTError: on error.

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -835,7 +835,8 @@ async def test_verify_docker_image_task_command(chain, docker_image_link):
 
 # verify_scriptworker_task {{{1
 @pytest.mark.parametrize("func", ["verify_balrog_task", "verify_beetmover_task",
-                                  "verify_signing_task", "verify_scriptworker_task"])
+                                  "verify_pushapk_task", "verify_signing_task",
+                                  "verify_scriptworker_task"])
 @pytest.mark.asyncio
 async def test_verify_scriptworker_task(chain, build_link, func):
     build_link.worker_impl = 'scriptworker'
@@ -843,7 +844,8 @@ async def test_verify_scriptworker_task(chain, build_link, func):
 
 
 @pytest.mark.parametrize("func", ["verify_balrog_task", "verify_beetmover_task",
-                                  "verify_signing_task", "verify_scriptworker_task"])
+                                  "verify_pushapk_task", "verify_signing_task",
+                                  "verify_scriptworker_task"])
 @pytest.mark.asyncio
 async def test_verify_scriptworker_task_worker_impl(chain, build_link, func):
     build_link.worker_impl = 'bad_impl'


### PR DESCRIPTION
@JohanLorenzo This adds initial pushapk support to the chain of trust verification in scriptworker.

Speaking of: we're ready to turn on tier1 taskcluster android nightlies tonight, and that will possibly merge to aurora next week.  If that happens, we would be able to then get pushapk into the nightly graph with chain of trust support, and we could turn off the pushapk scheduler.

If that doesn't happen next week, we're still thinking about getting tc android nightlies turned on in Aurora over the next 6-7 weeks, so it'll happen sooner or later.