### PR TITLE
start using `unfreeze_values`

### DIFF
--- a/scriptworker/config.py
+++ b/scriptworker/config.py
@@ -65,24 +65,27 @@ def unfreeze_values(dictionary):
     A recursive function(top-down conversion)
 
     Args:
-        dictionary(frozendict/tuple): the frozendict/tuple to modify in-place.
+        dictionary(frozendict/tuple): the frozendict/tuple.
+
+    Returns:
+        dictionary (dict/list): the unfrozen copy.
     """
-    if isinstance(dictionary, dict):
+    if isinstance(dictionary, (frozendict, dict)):
+        dictionary = dict(deepcopy(dictionary))
         for key, value in dictionary.items():
             if isinstance(value, tuple):
-                dictionary[key] = list(value)
-                unfreeze_values(dictionary[key])
+                dictionary[key] = unfreeze_values(dictionary[key])
             elif isinstance(value, frozendict):
-                dictionary[key] = value.__dict__['_dict']
-                unfreeze_values(dictionary[key])
-    elif isinstance(dictionary, list):
+                dictionary[key] = unfreeze_values(dictionary[key])
+    elif isinstance(dictionary, (list, tuple)):
+        dictionary = list(dictionary)
         for idx in range(len(dictionary)):
             if isinstance(dictionary[idx], tuple):
-                dictionary[idx] = list(dictionary[idx])
-                unfreeze_values(dictionary[idx])
+                dictionary[idx] = unfreeze_values(dictionary[idx])
             elif isinstance(dictionary[idx], frozendict):
-                dictionary[idx] = dictionary[idx].__dict__['_dict']
-                unfreeze_values(dictionary[idx])
+                dictionary[idx] = unfreeze_values(dictionary[idx])
+
+    return dictionary
 
 
 # read_worker_creds {{{1

--- a/scriptworker/test/__init__.py
+++ b/scriptworker/test/__init__.py
@@ -6,13 +6,13 @@ import aiohttp
 import arrow
 import asyncio
 from copy import deepcopy
-from frozendict import frozendict
 import json
 import mock
 import os
 import pytest
 import tempfile
 import taskcluster.exceptions
+from scriptworker.config import unfreeze_values
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context
 from scriptworker.utils import makedirs
@@ -261,7 +261,7 @@ def tmpdir2():
 def rw_context():
     with tempfile.TemporaryDirectory() as tmp:
         context = Context()
-        context.config = dict(deepcopy(DEFAULT_CONFIG))
+        context.config = unfreeze_values(DEFAULT_CONFIG)
         context.config['gpg_lockfile'] = os.path.join(tmp, 'gpg_lockfile')
         context.config['cot_job_type'] = "signing"
         for key, value in context.config.items():
@@ -270,8 +270,6 @@ def rw_context():
                 makedirs(context.config[key])
             if key.endswith("key_path") or key in ("gpg_home", ):
                 context.config[key] = os.path.join(tmp, key)
-            if isinstance(value, frozendict):
-                context.config[key] = dict(value)
         yield context
 
 

--- a/scriptworker/test/test_config.py
+++ b/scriptworker/test/test_config.py
@@ -56,12 +56,23 @@ def test_freeze_values(input_dict, expected_dict):
     assert input_dict == expected_dict
 
 
-@pytest.mark.parametrize("input_dict,expected_dict", (({1: 2}, {1: 2}), ({1: (1, 2)}, {1: [1, 2]}), ({1: frozendict({2: 3})}, {1: {2: 3}}),
-                                                      ({1: (frozendict({2: 3}), (4, 5, 6))}, {1: [{2: 3}, [4, 5, 6]]}),
-                                                      ({1: (1, (2, 3), frozendict({4: 5}))}, {1: [1, [2, 3], {4: 5}]}), ((1, 2), (1, 2))))
+@pytest.mark.parametrize("input_dict,expected_dict", ((
+    {1: 2}, {1: 2}
+), (
+    {1: (1, 2)}, {1: [1, 2]}
+), (
+    {1: frozendict({2: 3})}, {1: {2: 3}}
+), (
+    {1: (frozendict({2: 3}), (4, 5, 6))}, {1: [{2: 3}, [4, 5, 6]]}
+), (
+    {1: (1, (2, 3), frozendict({4: 5}))}, {1: [1, [2, 3], {4: 5}]}
+), (
+    (1, 2), [1, 2]
+), (
+    1, 1
+)))
 def test_unfreeze_values(input_dict, expected_dict):
-    config.unfreeze_values(input_dict)
-    assert input_dict == expected_dict
+    assert config.unfreeze_values(input_dict) == expected_dict
 
 
 # check_config {{{1

--- a/scriptworker/test/test_integration.py
+++ b/scriptworker/test/test_integration.py
@@ -5,14 +5,12 @@
 import aiohttp
 import arrow
 from contextlib import contextmanager
-from copy import deepcopy
-from frozendict import frozendict
 import json
 import os
 import pytest
 import slugid
 import tempfile
-from scriptworker.config import CREDS_FILES, read_worker_creds
+from scriptworker.config import CREDS_FILES, read_worker_creds, unfreeze_values
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context
 import scriptworker.log as swlog
@@ -51,10 +49,7 @@ To skip integration tests, set the environment variable NO_TESTS_OVER_WIRE""".fo
 
 def build_config(override, basedir):
     randstring = slugid.nice()[0:6].decode('utf-8')
-    config = dict(deepcopy(DEFAULT_CONFIG))
-    for k, v in config.items():
-        if isinstance(v, frozendict):
-            config[k] = dict(v)
+    config = unfreeze_values(DEFAULT_CONFIG)
     GPG_HOME = os.path.join(os.path.basename(__file__), "data", "gpg")
     config.update({
         'log_dir': os.path.join(basedir, "log"),


### PR DESCRIPTION
This is a bigger patch than I was expecting, mainly because I didn't
catch some errors in the initial `unfreeze_values` patch.

@johanlorenzo how does this look?  This doesn't block anything, but might be nice to fix before we roll out 2.0.0b1 :)