### PR TITLE
Bug 1333394 - Use the new name of docker-images

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -179,7 +179,8 @@ DEFAULT_CONFIG = frozendict({
 
     # docker-image cot
     "valid_docker_image_worker_types": (
-        "taskcluster-images",
+        "taskcluster-images",   # TODO: Remove this image once docker-images is the only valid worker type
+        "gecko-images",
     ),
 
     "valid_docker_image_env_vars": (


### PR DESCRIPTION
It seems like a [renaming happened 2 weeks ago](https://bugzilla.mozilla.org/show_bug.cgi?id=1320328). This causes [issues described here](https://bugzilla.mozilla.org/show_bug.cgi?id=1333394).

@escapewindow , if I'm correct, we're gonna need v1.0.0b8 quickly. I can prepare a v1 branch upon which I can backport this patch.