### PR TITLE
Bug 1333394 - Use the new name of docker-images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [1.0.0b8] - 2017-01-24
 
 ### Fixed
 - CoT failed because of the new names of docker images. See [bug 1333394](https://bugzilla.mozilla.org/show_bug.cgi?id=1333394).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- CoT failed because of the new names of docker images. See [bug 1333394](https://bugzilla.mozilla.org/show_bug.cgi?id=1333394).
+
 ## [1.0.0b7] - 2017-01-18
 ### Added
 - `unfreeze_values`, to unfreeze a `freeze_values` frozendict.

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -178,7 +178,8 @@ DEFAULT_CONFIG = frozendict({
 
     # docker-image cot
     "valid_docker_image_worker_types": (
-        "taskcluster-images",
+        "taskcluster-images",   # TODO: Remove this image once docker-images is the only valid worker type
+        "gecko-images",
     ),
 
     "valid_docker_image_env_vars": (

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -50,7 +50,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (1, 0, 0, "beta7")
+__version__ = (1, 0, 0, "beta8")
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,9 +1,9 @@
 {
     "version": [
-        1, 
-        0, 
-        0, 
-        "beta7"
-    ], 
-    "version_string": "1.0.0-beta7"
+        1,
+        0,
+        0,
+        "beta8"
+    ],
+    "version_string": "1.0.0-beta8"
 }


### PR DESCRIPTION
Backport of #66 on the v1 branch. This allows to release v1.0.0b8. 