### PR TITLE
2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [2.0.0] - 2017-01-25
 ### Added
 - `scriptworker.artifacts` is a new submodule that defines artifact behavior
 - we now support `pushapk` scriptworker instance types in `cot.verify`
@@ -16,6 +16,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `.asc` files are now forced to `text/plain`
 - all `text/plain` artifacts are now gzipped, including .log, .asc, .json, .html, .xml
 - we no longer have `task_output.log` and `task_error.log`.  Instead, we have `live_backing.log`, for more treeherder-friendliness
+
+### Removed
+- stop testing for task environment variables.  This is fragile and provides little benefit; let's push on [bug 1328719](https://bugzilla.mozilla.org/show_bug.cgi?id=1328719) instead.
 
 ## [1.0.0b7] - 2017-01-18
 ### Added

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -148,59 +148,11 @@ DEFAULT_CONFIG = frozendict({
     "valid_decision_worker_types": (
         "gecko-decision",
     ),
-    "valid_decision_env_vars": (
-        "GECKO_BASE_REPOSITORY",
-        "GECKO_HEAD_REPOSITORY",
-        "GECKO_HEAD_REF",
-        "GECKO_HEAD_REV",
-        "HG_STORE_PATH",
-    ),
-
-    # docker-worker build/l10n cot
-    "valid_docker_worker_build_env_vars": (
-        "EN_US_BINARY_URL",
-        "EN_US_PACKAGE_NAME",
-        "GECKO_BASE_REPOSITORY",
-        "GECKO_HEAD_REPOSITORY",
-        "GECKO_HEAD_REV",
-        "HG_STORE_PATH",
-        "JOB_SCRIPT",
-        "MH_BRANCH",
-        "MH_BUILD_POOL",
-        "MH_CUSTOM_BUILD_VARIANT_CFG",
-        "MOZHARNESS_ACTIONS",
-        "MOZHARNESS_CONFIG",
-        "MOZHARNESS_OPTIONS",
-        "MOZHARNESS_SCRIPT",
-        "MOZ_BUILD_DATE",
-        "MOZ_SCM_LEVEL",
-        "NEED_XVFB",
-        "TOOLTOOL_CACHE",
-        "TOOLTOOL_REPO",
-        "TOOLTOOL_REV",
-        "USE_SCCACHE",
-    ),
 
     # docker-image cot
     "valid_docker_image_worker_types": (
         "taskcluster-images",   # TODO: Remove this image once docker-images is the only valid worker type
         "gecko-images",
-    ),
-
-    "valid_docker_image_env_vars": (
-        "GECKO_BASE_REPOSITORY",
-        "GECKO_HEAD_REV",
-        "GECKO_HEAD_REPOSITORY",
-        "HEAD_REF",
-        "HG_STORE_PATH",
-        "IMAGE_NAME",
-        "PROJECT",
-        "CONTEXT_URL",
-        "HEAD_REPOSITORY",
-        "CONTEXT_PATH",
-        "HEAD_REV",
-        "BASE_REPOSITORY",
-        "HASH",
     ),
 
     # for trace_back_to_*_tree.  These repos have access to restricted scopes;

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -50,7 +50,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (1, 0, 0, "beta7")
+__version__ = (2, 0, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,9 +1,8 @@
 {
     "version": [
-        1, 
-        0, 
-        0, 
-        "beta7"
-    ], 
-    "version_string": "1.0.0-beta7"
+        2,
+        0,
+        0
+    ],
+    "version_string": "2.0.0"
 }


### PR DESCRIPTION
Let's stop playing around with shipping betas to avoid bumping the major version number.  Now that we're post-1.0.0 final, the major version should increment fairly regularly whenever we add backwards-incompatible changes.

This is 2.0.0 because it has non-backwards-compatible changes since 1.0.0b8.  3.0.0 won't be far away.