### PR TITLE
bug 1333895 - make retries more robust.

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -56,7 +56,7 @@ DEFAULT_CONFIG = frozendict({
     "task_log_dir": "...",  # set this to ARTIFACT_DIR/public/logs
     "git_commit_signing_pubkey_dir": "...",
     "artifact_upload_timeout": 60 * 20,
-    "aiohttp_max_connections": 30,
+    "aiohttp_max_connections": 15,
 
     # chain of trust settings
     "sign_chain_of_trust": True,
@@ -241,5 +241,6 @@ STATUSES = {
     'resource-unavailable': 4,
     'internal-error': 5,
     'superseded': 6,
+    'intermittent-task': 7,
 }
 REVERSED_STATUSES = {v: k for k, v in STATUSES.items()}

--- a/scriptworker/test/test_worker.py
+++ b/scriptworker/test/test_worker.py
@@ -157,9 +157,9 @@ def test_mocker_run_loop_noop(context, successful_queue, event_loop, mocker):
 ), (
     'upload_artifacts', ScriptWorkerException, ScriptWorkerException.exit_code
 ), (
-    'upload_artifacts', aiohttp.errors.DisconnectedError, STATUSES['resource-unavailable']
+    'upload_artifacts', aiohttp.errors.DisconnectedError, STATUSES['intermittent-task']
 ), (
-    'upload_artifacts', aiohttp.errors.ClientError, STATUSES['resource-unavailable']
+    'upload_artifacts', aiohttp.errors.ClientError, STATUSES['intermittent-task']
 )))
 def test_mocker_run_loop_exception(context, successful_queue, event_loop,
                                    mocker, func_to_raise, exc, expected):

--- a/scriptworker/utils.py
+++ b/scriptworker/utils.py
@@ -178,7 +178,7 @@ def cleanup(context):
 
 # calculate_sleep_time {{{1
 def calculate_sleep_time(attempt, delay_factor=5.0, randomization_factor=.5, max_delay=120):
-    """Calculate the sleep time between retries.
+    """Calculate the sleep time between retries, in seconds.
 
     Based off of `taskcluster.utils.calculateSleepTime`, but with kwargs instead
     of constant `delay_factor`/`randomization_factor`/`max_delay`.  The taskcluster
@@ -189,11 +189,11 @@ def calculate_sleep_time(attempt, delay_factor=5.0, randomization_factor=.5, max
         attempt (int): the retry attempt number
         delay_factor (float, optional): a multiplier for the delay time.  Defaults to 5.
         randomization_factor (float, optional): a randomization multiplier for the
-            delay time.  Defaults to .25.
-        max_delay (float, optional): the max delay to sleep.  Defaults to 120.
+            delay time.  Defaults to .5.
+        max_delay (float, optional): the max delay to sleep.  Defaults to 120 (seconds).
 
     Returns:
-        float: the time to sleep
+        float: the time to sleep, in seconds.
     """
     if attempt <= 0:
         return 0
@@ -246,7 +246,7 @@ async def retry_async(func, attempts=5, sleeptime_callback=calculate_sleep_time,
                 raise
             sleeptime_kwargs = sleeptime_kwargs or {}
             sleep_time = sleeptime_callback(attempt, **sleeptime_kwargs)
-            log.debug("retry_async: {}: sleeping {} before retry".format(func, sleep_time))
+            log.debug("retry_async: {}: sleeping {} seconds before retry".format(func, sleep_time))
             await asyncio.sleep(sleep_time)
 
 

--- a/scriptworker/worker.py
+++ b/scriptworker/worker.py
@@ -68,7 +68,7 @@ async def run_loop(context, creds_key="credentials"):
                 status = worst_level(status, e.exit_code)
                 log.error("Hit ScriptWorkerException: {}".format(e))
             except (aiohttp.errors.DisconnectedError, aiohttp.errors.ClientError) as e:
-                status = worst_level(status, STATUSES['resource-unavailable'])
+                status = worst_level(status, STATUSES['intermittent-task'])
                 log.error("Hit aiohttp error: {}".format(e))
             await complete_task(context, status)
             cleanup(context)


### PR DESCRIPTION
- reduce `aiohttp_max_connections` to 15
- add `intermittent-task` status; use it for aiohttp exceptions in
`scriptworker.worker.run_loop`
- add a `retry_async_kwargs` kwarg to `retry_request`
- add a `scriptworker.utils.calculate_sleep_time` function, because
`taskcluster.utils.calculateSleepTime` generally returns a value less
than 1, and our retries need more flexibility.
- add a `sleeptime_kwargs` kwarg to `retry_async
- add full `scriptworker.utils` test coverage.  We had coverage from
calling other functions that called `scriptworker.utils` functions
already, but now `scriptworker.test.test_utils` fully and directly
tests `scriptworker.utils`.

This also pins `taskcluster<1.0.0` until https://github.com/taskcluster/taskcluster-client.py/issues/58 is fixed.

This should address #20 .