### PR TITLE
fix taskcluster>=1.0.0 support; improve upload logging

### DIFF
--- a/scriptworker/artifacts.py
+++ b/scriptworker/artifacts.py
@@ -189,7 +189,7 @@ async def create_artifact(context, path, target_path, content_type, content_enco
                 tc_response['putUrl'], data=fh, headers=_craft_artifact_put_headers(content_type, content_encoding),
                 skip_auto_headers=skip_auto_headers, compress=False
             ) as resp:
-                log.info(resp.status)
+                log.info("create_artifact {}: {}".format(path, resp.status))
                 response_text = await resp.text()
                 log.info(response_text)
                 if resp.status not in (200, 204):

--- a/scriptworker/artifacts.py
+++ b/scriptworker/artifacts.py
@@ -225,14 +225,20 @@ def get_artifact_url(context, task_id, path):
     Raises:
         TaskClusterFailure: on failure.
     """
-    url = urljoin(
-        context.queue.options['baseUrl'],
-        'v1/' +
-        unquote(context.queue.makeRoute('getLatestArtifact', replDict={
-            'taskId': task_id,
-            'name': path
-        }))
-    )
+    try:
+        url = unquote(context.queue.buildUrl('getLatestArtifact', task_id, path))
+    except AttributeError:
+        # taskcluster client 0.3.x
+        # XXX remove when we no longer want to support taskcluster<1.0.0
+        url = urljoin(
+            context.queue.options['baseUrl'],
+            'v1/' +
+            unquote(context.queue.makeRoute('getLatestArtifact', replDict={
+                'taskId': task_id,
+                'name': path
+            }))
+        )
+
     return url
 
 

--- a/scriptworker/test/test_artifacts.py
+++ b/scriptworker/test/test_artifacts.py
@@ -17,7 +17,6 @@ from scriptworker.exceptions import ScriptWorkerRetryException
 from . import touch, rw_context, event_loop, fake_session, fake_session_500, successful_queue
 
 
-# TODO avoid copying this fixture
 @pytest.yield_fixture(scope='function')
 def context(rw_context):
     rw_context.config['artifact_expiration_hours'] = 1
@@ -162,7 +161,14 @@ def test_craft_artifact_put_headers():
 
 
 # get_artifact_url {{{1
-def test_get_artifact_url():
+@pytest.mark.parametrize("tc03x", (True, False))
+def test_get_artifact_url(tc03x):
+
+    def buildUrl(*args, **kwargs):
+        if tc03x:
+            raise AttributeError("foo")
+        else:
+            return "https://netloc/v1/rel/path"
 
     def makeRoute(*args, **kwargs):
         return "rel/path"
@@ -171,6 +177,7 @@ def test_get_artifact_url():
     context.queue = mock.MagicMock()
     context.queue.options = {'baseUrl': 'https://netloc/'}
     context.queue.makeRoute = makeRoute
+    context.queue.buildUrl = buildUrl
     assert get_artifact_url(context, "x", "y") == "https://netloc/v1/rel/path"
 
 


### PR DESCRIPTION
First, `taskcluster>=1.0.0` changes how we make new artifact urls.  I think this is an improvement, but it breaks `get_artifact_url`.  I added support for 1.0.x without breaking 0.3.x for now; we can tear out 0.3.x support once we're on >=1.0.0 for a while and don't foresee needing to go back.

Second, while debugging async uploads, we see lots of this:

```
2017-01-25 19:29:53,340 - scriptworker.utils - DEBUG - retry_async: <function put at 0x7f99bcc7f2f0>: sleeping before retry
2017-01-25 19:29:53,341 - beetmoverscript.script - INFO - 200
2017-01-25 19:29:53,342 - beetmoverscript.script - INFO - 
2017-01-25 19:29:53,349 - beetmoverscript.script - INFO - 200
2017-01-25 19:29:53,350 - beetmoverscript.script - INFO - 
2017-01-25 19:29:53,355 - beetmoverscript.script - INFO - 200
2017-01-25 19:29:53,357 - beetmoverscript.script - INFO - 
2017-01-25 19:29:53,360 - beetmoverscript.script - INFO - 200
2017-01-25 19:29:53,363 - beetmoverscript.script - INFO - 
2017-01-25 19:29:56,922 - beetmoverscript.script - INFO - 400
```

It's not clear which artifacts are succeeding and which are retrying.  By adding the path before the status, we'll be able to debug a bit easier.  We'll need a similar patch for beetmoverscript.