### PR TITLE
2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.1] - 2017-02-02
+### Fixed
+- `get_artifact_url` now works with `taskcluster==1.0.2`, while keeping 0.3.x compatibility
+- more verbose upload status
+
 ## [2.1.0] - 2017-01-31
 ### Added
 - `intermittent-task` status

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -50,7 +50,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (2, 1, 0)
+__version__ = (2, 1, 1)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
-        2,
-        1,
-        0
-    ],
-    "version_string": "2.1.0"
+        2, 
+        1, 
+        1
+    ], 
+    "version_string": "2.1.1"
 }


### PR DESCRIPTION
- `get_artifact_url` now works with `taskcluster==1.0.2`, while keeping 0.3.x compatibility
- more verbose upload status