### PR TITLE
add python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: python
-python:
-  - 3.5.2
+
+matrix:
+  include:
+    - python: 3.5
+      env: TOXENV=py35 NO_TESTS_OVER_WIRE=1
+    - python: 3.6
+      env: TOXENV=py36 NO_TESTS_OVER_WIRE=1
 
 install:
-    - python -mpip install tox
-env:
-    NO_TESTS_OVER_WIRE=1
+  - python -mpip install tox
 script:
-    - tox
+  - tox
 after_success:
-    - tox -e py35-coveralls
+  - tox -e coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35
+envlist = py35,py36
 
 [testenv]
 recreate = True
@@ -30,7 +30,7 @@ commands=
     coverage html
     flake8
 
-[testenv:py35-coveralls]
+[testenv:coveralls]
 deps=
     python-coveralls
     coverage>=4.2


### PR DESCRIPTION
we probably still need to wait until taskcluster-client.py fully
supports py36 to switch over, but running py36 tests will allow us
to keep py36 scriptworker green in the meantime.