### PR TITLE
allow for retriggered decision tasks

### DIFF
--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -814,7 +814,7 @@ async def test_verify_scriptworker_task_worker_impl(chain, build_link, func):
 
 
 # check_num_tasks {{{1
-@pytest.mark.parametrize("num,raises", ((1, False), (2, False), (3, True), (0, True)))
+@pytest.mark.parametrize("num,raises", ((1, False), (2, False), (3, False), (0, True)))
 def test_check_num_tasks(chain, num, raises):
     if raises:
         with pytest.raises(CoTError):


### PR DESCRIPTION
Only look for tasks inside the task-graph.json if they are not decision
tasks.  (If we generate decision tasks inside the task graph that can
not themselves be traceable back to the tree standalone, we'll need to
revisit this decision.)

Also, allow for more than 2 decision tasks.

Fixes #77 (references https://bugzilla.mozilla.org/show_bug.cgi?id=1338933 )