### PR TITLE
add helper scripts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include scriptworker/data *
 recursive-include scriptworker/test/data *
 recursive-include docker *
+recursive-include helper_scripts *
 
 include .coveragerc
 include CHANGELOG.md

--- a/docs/chain_of_trust.md
+++ b/docs/chain_of_trust.md
@@ -116,7 +116,13 @@ The pubkeys for build, decision, and docker-image workerTypes should be added to
 
 First, you will need access to a trusted key (The trusted keys are in the [scriptworker/trusted dir](https://github.com/mozilla-releng/cot-gpg-keys/tree/master/scriptworker/trusted).  That may mean someone else needs to generate the keys, or you may petition for access to create and sign these keys.  (To do so, update the trusted keys with a new pubkey, sign that commit with a trusted git commit key, and merge.  If you don't have a trusted git key, see [adding new git commit signing gpg keys](#adding-new-git-commit-signing-gpg-keys).)
 
-Once you have access to a trusted key, generate new gpg keypairs for each host.  The email address will be `username`@`fqdn`, e.g. `cltsign@signing-linux-1.srv.releng.use1.mozilla.com`.  You can use a script like [this](https://bug1298553.bmoattachments.org/attachment.cgi?id=8792961)... (it may be a good idea to make that script generic and land it in the scriptworker repo).
+Once you have access to a trusted key, generate new gpg keypairs for each host.  The email address will be `username`@`fqdn`, e.g. `cltsign@signing-linux-1.srv.releng.use1.mozilla.com`.  You can use [this script](https://github.com/mozilla-releng/scriptworker/blob/master/helper_scripts/create_gpg_keys.py), like
+
+```bash
+scriptworker/helper_scripts/create_gpg_keys.py -u cltsign -s host1.fqdn.com host2.fqdn.com
+# This will generate a gpg homedir in ./gpg
+# Keys will be written to ./host{1,2}.fqdn.com.{pub,sec}
+```
 
 Next, sign the newly created gpg keys with your trusted gpg key.
 

--- a/helper_scripts/create_gpg_keys.py
+++ b/helper_scripts/create_gpg_keys.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python
+"""Create gpg keys for scriptworker instances."""
 
 import argparse
 import gnupg
+import logging
 import os
 import shutil
 import scriptworker.gpg
 
 
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
 class FullPaths(argparse.Action):
-    """Expand user- and relative-paths"""
+    """Expand user- and relative-paths."""
 
     def __call__(self, parser, namespace, values, option_string=None):
+        """Override the Action __call__ method."""
         setattr(namespace, self.dest, os.path.abspath(os.path.expanduser(values)))
 
 
@@ -19,12 +26,8 @@ parser.add_argument('-b', '--gpgbin', nargs='?', help="GPG binary used", action=
                     default="/usr/local/bin/gpg2")
 parser.add_argument('-o', '--gpghome', nargs='?', help="GPG home folder", action=FullPaths,
                     default=os.path.join(os.getcwd(), "gpg"))
-parser.add_argument('-u', '--username', nargs='?', help="Email username", default="cltsign")
-parser.add_argument('-s', '--hosts', nargs='+', help="Host names to generate for",
-                    default=["signing-linux-1.srv.releng.use1.mozilla.com",
-                             "signing-linux-2.srv.releng.usw2.mozilla.com",
-                             "signing-linux-3.srv.releng.use1.mozilla.com",
-                             "signing-linux-4.srv.releng.usw2.mozilla.com"])
+parser.add_argument('-u', '--username', nargs='?', help="Email username", required=True)
+parser.add_argument('-s', '--hosts', nargs='+', help="Host names to generate for", required=True)
 parser.add_argument('-e', '--expires', nargs='?', help="Validity period for key", default="2y")
 parser.add_argument('--clean', action='store_true', default=False)
 args = parser.parse_args()
@@ -36,6 +39,8 @@ hosts = args.hosts
 duration = args.expires
 cleanup = args.clean
 
+log.info("Using gnupghome {}".format(gpghome))
+
 gpg = gnupg.GPG(
     gnupghome=gpghome,
     keyring=os.path.join(gpghome, "pubring.gpg"),
@@ -44,15 +49,20 @@ gpg = gnupg.GPG(
 )
 
 if cleanup:
-    shutil.rmtree(gpghome)
+    try:
+        shutil.rmtree(gpghome)
+    except FileNotFoundError:
+        pass
     os.makedirs(gpghome)
 
 for host in hosts:
+    log.info("Creating key for {}@{}".format(user, host))
     name = host.split('.')[0]
     fingerprint = scriptworker.gpg.generate_key(
         gpg, name, '', user + '@{}'.format(host),
         expiration=duration
     )
+    log.info("Writing to %s.{pub,sec}", name)
     for pvt in (True, False):
         key = scriptworker.gpg.export_key(gpg, fingerprint, private=pvt)
         suffix = ".pub"

--- a/helper_scripts/create_gpg_keys.py
+++ b/helper_scripts/create_gpg_keys.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import argparse
+import gnupg
+import os
+import shutil
+import scriptworker.gpg
+
+
+class FullPaths(argparse.Action):
+    """Expand user- and relative-paths"""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, os.path.abspath(os.path.expanduser(values)))
+
+
+parser = argparse.ArgumentParser(description="GPG keypair creation and export script")
+parser.add_argument('-b', '--gpgbin', nargs='?', help="GPG binary used", action=FullPaths,
+                    default="/usr/local/bin/gpg2")
+parser.add_argument('-o', '--gpghome', nargs='?', help="GPG home folder", action=FullPaths,
+                    default=os.path.join(os.getcwd(), "gpg"))
+parser.add_argument('-u', '--username', nargs='?', help="Email username", default="cltsign")
+parser.add_argument('-s', '--hosts', nargs='+', help="Host names to generate for",
+                    default=["signing-linux-1.srv.releng.use1.mozilla.com",
+                             "signing-linux-2.srv.releng.usw2.mozilla.com",
+                             "signing-linux-3.srv.releng.use1.mozilla.com",
+                             "signing-linux-4.srv.releng.usw2.mozilla.com"])
+parser.add_argument('-e', '--expires', nargs='?', help="Validity period for key", default="2y")
+parser.add_argument('--clean', action='store_true', default=False)
+args = parser.parse_args()
+
+gpgbinary = args.gpgbin
+gpghome = args.gpghome
+user = args.username
+hosts = args.hosts
+duration = args.expires
+cleanup = args.clean
+
+gpg = gnupg.GPG(
+    gnupghome=gpghome,
+    keyring=os.path.join(gpghome, "pubring.gpg"),
+    secret_keyring=os.path.join(gpghome, "secring.gpg"),
+    gpgbinary=gpgbinary,
+)
+
+if cleanup:
+    shutil.rmtree(gpghome)
+    os.makedirs(gpghome)
+
+for host in hosts:
+    name = host.split('.')[0]
+    fingerprint = scriptworker.gpg.generate_key(
+        gpg, name, '', user + '@{}'.format(host),
+        expiration=duration
+    )
+    for pvt in (True, False):
+        key = scriptworker.gpg.export_key(gpg, fingerprint, private=pvt)
+        suffix = ".pub"
+        if pvt:
+            suffix = ".sec"
+        with open("{}{}".format(name, suffix), "w") as fh:
+            print(key, file=fh, end='')

--- a/helper_scripts/gpg_helper.sh
+++ b/helper_scripts/gpg_helper.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+OPTIND=1
+
+while getopts "b:h:" opt; do
+    case "$opt" in
+        b)
+            GPGBIN=${OPTARG:-$GPGBIN}
+            ;;
+        h)
+            GPGHOME=${OPTARG:-$GPGHOME}
+            ;;
+        esac
+done
+
+shift $((OPTIND-1))
+
+[ "$1" = "--" ] && shift
+
+if [ -z "$GPGBIN" ];
+    then GPGBIN="/usr/bin/gpg"
+fi
+
+$GPGBIN --no-default-keyring --secret-keyring "$GPGHOME"/secring.gpg --keyring "$GPGHOME"/pubring.gpg "$@"

--- a/helper_scripts/gpg_helper.sh
+++ b/helper_scripts/gpg_helper.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# Usage: $0 -b PATH_TO_GPG -h GPG_HOME -- GPG_ARGS
 OPTIND=1
 
 while getopts "b:h:" opt; do


### PR DESCRIPTION
This is still a work in progress and shouldn't be merged currently.

Add gpg_helper.sh script which allows running of gpg commands with a specific gpg binary and over a particular gpg homedir, declared either as environment variables or as command line arguments.

The issue with using `getopts` to enable the use of named arguments (`-b` for the binary and `-h` for the home folder) is that it requires to separate the rest of the commands with a double dash (`--`).

This way, for example, invoking the script would look like `./gpg_helper.sh -b /usr/local/bin/gpg2 -h ~/.gnupg -- --list-all`

Another option would be to ditch the use of getopts and just rely on the position of the arguments (the first argument would be the binary, the second the home folder, the rest would be gpg commands), which would make the script invocation be `./gpg_helper.sh /usr/local/bin/gpg2 ~/.gnupg --list-all` but which has the downside of breaking if the users doesn't use the arguments in the correct order.

A third option would be to write a custom argument parser, but for such a small script I'm not sure if it's worth the effort.

Any preferred way to proceed with the shell script?

Fixes #65 