### PR TITLE
Bug 1338186 - add beetmover/balrog release scopes. r=aki

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -176,14 +176,17 @@ DEFAULT_CONFIG = frozendict({
     # Map scopes to restricted-level
     'cot_restricted_scopes': frozendict({
         'firefox': frozendict({
-            'project:releng:balrog:server:release': 'all-release-branches',
+            'project:releng:balrog:server:release': 'release',
+            'project:releng:balrog:server:beta': 'beta',
+            'project:releng:balrog:server:aurora': 'aurora',
+            'project:releng:balrog:server:esr': 'esr',
             'project:releng:beetmover:bucket:release': 'all-release-branches',
             'project:releng:googleplay:release': 'release',
             'project:releng:signing:cert:release-signing': 'all-release-branches',
             'project:releng:googleplay:beta': 'beta',
             'project:releng:googleplay:aurora': 'aurora',
             'project:releng:balrog:nightly': 'all-nightly-branches',
-            'project:releng:balrog:server:nightly': 'all-nightly-branches',
+            'project:releng:balrog:server:nightly': 'nightly',
             'project:releng:beetmover:nightly': 'all-nightly-branches',
             'project:releng:beetmover:bucket:nightly': 'all-nightly-branches',
             'project:releng:signing:cert:nightly-signing': 'all-nightly-branches',
@@ -214,6 +217,14 @@ DEFAULT_CONFIG = frozendict({
             'aurora': (
                 "/releases/mozilla-aurora",
             ),
+            'esr': (
+                "/releases/mozilla-esr45",
+                "/releases/mozilla-esr52",
+            ),
+            'nightly': (
+                "/mozilla-central",
+            ),
+
             # Which repos can do nightly signing?
             # XXX remove /projects/date when taskcluster nightly migration is
             #     tier1 and landed on mozilla-central

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -176,14 +176,16 @@ DEFAULT_CONFIG = frozendict({
     # Map scopes to restricted-level
     'cot_restricted_scopes': frozendict({
         'firefox': frozendict({
-            'project:releng:balrog:release': 'all-release-branches',
-            'project:releng:beetmover:release': 'all-release-branches',
+            'project:releng:balrog:server:release': 'all-release-branches',
+            'project:releng:beetmover:bucket:release': 'all-release-branches',
             'project:releng:googleplay:release': 'release',
             'project:releng:signing:cert:release-signing': 'all-release-branches',
             'project:releng:googleplay:beta': 'beta',
             'project:releng:googleplay:aurora': 'aurora',
             'project:releng:balrog:nightly': 'all-nightly-branches',
+            'project:releng:balrog:server:nightly': 'all-nightly-branches',
             'project:releng:beetmover:nightly': 'all-nightly-branches',
+            'project:releng:beetmover:bucket:nightly': 'all-nightly-branches',
             'project:releng:signing:cert:nightly-signing': 'all-nightly-branches',
         })
     }),


### PR DESCRIPTION
Since we didn't get to ship any release with current {beetmover,balrog}script workers, I think it's safe to overwrite the release-related ones with the new scopes format. For the nightly scopes, we keep the old scopes and add the new scope format. We're likely to delete the former once testing is done and we're backward compatible and green to go.