### PR TITLE
CoT verify: Allow to declare several times the same task type

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -185,8 +185,8 @@ DEFAULT_CONFIG = frozendict({
             'project:releng:beetmover:bucket:release': 'all-release-branches',
             'project:releng:googleplay:release': 'release',
             'project:releng:signing:cert:release-signing': 'all-release-branches',
-            'project:releng:googleplay:beta': 'beta',
-            'project:releng:googleplay:aurora': 'aurora',
+            'project:releng:googleplay:beta': 'betatest',
+            'project:releng:googleplay:aurora': 'auroratest',
             'project:releng:beetmover:bucket:nightly': 'all-nightly-branches',
             'project:releng:signing:cert:nightly-signing': 'all-nightly-branches',
         })
@@ -213,8 +213,18 @@ DEFAULT_CONFIG = frozendict({
             'beta': (
                 "/releases/mozilla-beta",
             ),
+            # TODO remove it once pushapk is landed on beta
+            'betatest': (
+                "/releases/mozilla-beta",
+                "/projects/jamun",
+            ),
             'aurora': (
                 "/releases/mozilla-aurora",
+            ),
+            # TODO remove it once pushapk is landed on aurora
+            'auroratest': (
+                "/releases/mozilla-aurora",
+                "/projects/date",
             ),
             'esr': (
                 "/releases/mozilla-esr45",


### PR DESCRIPTION
Fixes #91. Unlike the solution suggested there, we use a sorted list of tuples instead of a dict. This simplifies the logic in `build_task_dependencies()`. 

Added new unit test. Also tested manually at https://tools.taskcluster.net/task-inspector/#GZI4I9GmSPW3kK_K_9xBmA/4 (the task failed for another reason that is not due to scriptworker).

r? @escapewindow 