### PR TITLE
support aiohttp 2.0.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-aiohttp
+aiohttp>=2.0.0
 arrow
 defusedxml
 frozendict

--- a/scriptworker/artifacts.py
+++ b/scriptworker/artifacts.py
@@ -141,8 +141,7 @@ async def retry_create_artifact(*args, **kwargs):
         create_artifact,
         retry_exceptions=(
             ScriptWorkerRetryException,
-            aiohttp.errors.DisconnectedError,
-            aiohttp.errors.ClientError
+            aiohttp.ClientError
         ),
         args=args,
         kwargs=kwargs

--- a/scriptworker/test/test_worker.py
+++ b/scriptworker/test/test_worker.py
@@ -157,9 +157,7 @@ def test_mocker_run_loop_noop(context, successful_queue, event_loop, mocker):
 ), (
     'upload_artifacts', ScriptWorkerException, ScriptWorkerException.exit_code
 ), (
-    'upload_artifacts', aiohttp.errors.DisconnectedError, STATUSES['intermittent-task']
-), (
-    'upload_artifacts', aiohttp.errors.ClientError, STATUSES['intermittent-task']
+    'upload_artifacts', aiohttp.ClientError, STATUSES['intermittent-task']
 )))
 def test_mocker_run_loop_exception(context, successful_queue, event_loop,
                                    mocker, func_to_raise, exc, expected):

--- a/scriptworker/worker.py
+++ b/scriptworker/worker.py
@@ -67,7 +67,7 @@ async def run_loop(context, creds_key="credentials"):
             except ScriptWorkerException as e:
                 status = worst_level(status, e.exit_code)
                 log.error("Hit ScriptWorkerException: {}".format(e))
-            except (aiohttp.errors.DisconnectedError, aiohttp.errors.ClientError) as e:
+            except aiohttp.ClientError as e:
                 status = worst_level(status, STATUSES['intermittent-task'])
                 log.error("Hit aiohttp error: {}".format(e))
             await complete_task(context, status)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools.command.test import test as TestCommand
 import sys
 
 reqs = [
-    "aiohttp",
+    "aiohttp>=2.0.0",
     "arrow",
     "defusedxml",
     "frozendict",


### PR DESCRIPTION
Addresses #93 .

We may want to look at all of http://aiohttp.readthedocs.io/en/stable/migration.html to make sure we're using aiohttp 2.0.0 properly.