### PR TITLE
Clean up google play scopes and switch Google Play Aurora to nightly.

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -190,6 +190,11 @@ DEFAULT_CONFIG = frozendict({
             'project:releng:googleplay:release': 'release',
             'project:releng:signing:cert:release-signing': 'all-release-branches',
             'project:releng:googleplay:beta': 'beta',
+            # As part of the Dawn project we decided to use the Aurora Google Play
+            # app to ship Firefox Nightly. This means that the "nightly" trees need
+            # to have the scopes to ship to this product.
+            # https://bugzilla.mozilla.org/show_bug.cgi?id=1357808 has additional
+            # background and discussion.
             'project:releng:googleplay:aurora': 'nightly',
             'project:releng:beetmover:bucket:nightly': 'all-nightly-branches',
             'project:releng:signing:cert:nightly-signing': 'all-nightly-branches',

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -189,8 +189,8 @@ DEFAULT_CONFIG = frozendict({
             'project:releng:beetmover:bucket:release': 'all-release-branches',
             'project:releng:googleplay:release': 'release',
             'project:releng:signing:cert:release-signing': 'all-release-branches',
-            'project:releng:googleplay:beta': 'betatest',
-            'project:releng:googleplay:aurora': 'auroratest',
+            'project:releng:googleplay:beta': 'beta',
+            'project:releng:googleplay:aurora': 'nightly',
             'project:releng:beetmover:bucket:nightly': 'all-nightly-branches',
             'project:releng:signing:cert:nightly-signing': 'all-nightly-branches',
         })
@@ -217,18 +217,8 @@ DEFAULT_CONFIG = frozendict({
             'beta': (
                 "/releases/mozilla-beta",
             ),
-            # TODO remove it once pushapk is landed on beta
-            'betatest': (
-                "/releases/mozilla-beta",
-                "/projects/jamun",
-            ),
             'aurora': (
                 "/releases/mozilla-aurora",
-            ),
-            # TODO remove it once pushapk is landed on aurora
-            'auroratest': (
-                "/releases/mozilla-aurora",
-                "/projects/date",
             ),
             'esr': (
                 "/releases/mozilla-esr45",


### PR DESCRIPTION
@JohanLorenzo and I talked about this a bit on IRC and decided we could clean up the other channels, too. I don't think there's any reason we need to have "date" in the scopes for Aurora, since we wouldn't want those builds pushed to the Play Store (the branding is wrong).