### PR TITLE
claimWork logging

### DIFF
--- a/scriptworker/task.py
+++ b/scriptworker/task.py
@@ -268,6 +268,7 @@ async def claim_work(context):
         dict: a dict containing a list of the task definitions of the tasks claimed.
 
     """
+    log.debug("Calling claimWork...")
     payload = {
         'workerGroup': context.config['worker_group'],
         'workerId': context.config['worker_id'],

--- a/scriptworker/test/test_worker.py
+++ b/scriptworker/test/test_worker.py
@@ -114,7 +114,7 @@ def test_mocker_run_loop(context, successful_queue, event_loop, verify_cot, mock
     mocker.patch.object(worker, "run_task", new=run_task)
     mocker.patch.object(worker, "ChainOfTrust", new=fake_cot)
     mocker.patch.object(worker, "verify_chain_of_trust", new=noop_async)
-    mocker.patch.object(worker, "generate_cot", new=noop_async)
+    mocker.patch.object(worker, "generate_cot", new=noop_sync)
     mocker.patch.object(worker, "upload_artifacts", new=noop_async)
     mocker.patch.object(worker, "complete_task", new=noop_async)
     status = event_loop.run_until_complete(worker.run_loop(context))


### PR DESCRIPTION
We now have nagios monitoring! Which checks `worker.log` age.

Previously, polling was very noisy, so we knew when scriptworker was running and not hung. Now, claimWork is very silent until we claim a task to run. Let's add a debug message, so we know we're running, and nagios doesn't alert.

Also, fix a test warning.