### PR TITLE
verify cot.taskId matches link.task_id

### DIFF
--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -176,6 +176,9 @@ class LinkOfTrust(object):
 
     @cot.setter
     def cot(self, cot):
+        cot_task_id = cot.get('taskId')
+        if cot_task_id != self.task_id:
+            raise CoTError("Chain of Trust artifact taskId {} doesn't match task taskId {}!".format(cot_task_id, self.task_id))
         self._set('_cot', cot)
 
     @property


### PR DESCRIPTION
We specify the `taskId` in the chain of trust artifact to help us verify
it matches the task we downloaded it from. We seem to be missing a test
to make sure they match. This patch adds that test.