### PR TITLE
signed tag, not signed commit

### DIFF
--- a/docs/cot_gpg_key_mgmt.rst
+++ b/docs/cot_gpg_key_mgmt.rst
@@ -79,7 +79,7 @@ Next, sign the newly created gpg keys with your trusted gpg key.
 
 .. code:: bash
 
-       gpg --import HOSTNAME.pub
+       gpg --import FQDN.pub
 
 2. sign pubkey
 
@@ -93,7 +93,7 @@ Next, sign the newly created gpg keys with your trusted gpg key.
 
 .. code:: bash
 
-    gpg --armor --export EMAIL > USERNAME@HOSTNAME.pub  # or fingerprint
+    gpg --armor --export EMAIL > USERNAME@FQDN.pub  # or fingerprint
 
 The signed pubkey + private key will need to go into hiera, as described
 `here <new_instance.html#puppet>`__.

--- a/docs/cot_gpg_key_mgmt.rst
+++ b/docs/cot_gpg_key_mgmt.rst
@@ -43,8 +43,8 @@ generate a new gpg keypair. The Taskcluster team has the option of
 recording the public key and adding it to the repo.
 
 The pubkeys for build, decision, and docker-image workerTypes should be
-added to the repo, with signed commits per the
-`readme <https://github.com/mozilla-releng/cot-gpg-keys/blob/master/README.md>`__.
+added to the repo, with a signed tag per the
+`readme <https://github.com/mozilla-releng/cot-gpg-keys/blob/master/README.md#tagging-git-commits>`__.
 
 new scriptworker gpg keys
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -100,4 +100,4 @@ The signed pubkey + private key will need to go into hiera, as described
 
 The signed pubkey will need to land in
 `scriptworker/valid <https://github.com/mozilla-releng/cot-gpg-keys/tree/master/scriptworker/valid>`__
-with a signed commit.
+with a signed tag, per `the readme <https://github.com/mozilla-releng/cot-gpg-keys/blob/master/README.md#tagging-git-commits>`__.

--- a/docs/new_instance.md
+++ b/docs/new_instance.md
@@ -55,6 +55,8 @@ Then puppetize (you need the deploy pass for this):
     PUPPET_SERVER=releng-puppet2.srv.releng.scl3.mozilla.com sh puppetize.sh
     # if we want to puppetize against an environment
     PUPPET_SERVER=releng-puppet2.srv.releng.scl3.mozilla.com PUPPET_EXTRA_OPTIONS="--environment=USER" sh puppetize.sh
+    # run puppet
+    puppet agent --test
 ```
 
 It is probably best to reboot after puppetizing.  After this point, it should Just Work.


### PR DESCRIPTION
We've moved from signed commits to signed tags in cot-gpg-keys. Updating the docs to match.