### PR TITLE
bug 1389978 - close the contextual log file handle

### DIFF
--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -143,4 +143,5 @@ def contextual_log_handler(context, path, log_obj=None, level=logging.DEBUG,
     contextual_handler.setFormatter(formatter)
     log_obj.addHandler(contextual_handler)
     yield
+    contextual_handler.close()
     log_obj.removeHandler(contextual_handler)


### PR DESCRIPTION
In [bug 1389978](https://bugzilla.mozilla.org/show_bug.cgi?id=1389978), Nick found we were keeping tons of old log filehandles open, which ate up a ton of disk. Let's not do that.