### PR TITLE
Stop rotating scriptworker logs in scriptworker; add WatchedFileHandler support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.0.0] - 2017-08-22
+### Added
+- `watch_log_file` pref, to watch the log file for `logrotate.d` (or other) rotation. Set this to true in production.
+
+### Changed
+- switched from `RotatingFileHandler` to `WatchedFileHandler` or `FileHandler`, depending on whether `watch_log_file` is set.
+
+### Removed
+- Non-backwards-compatible: removed `log_max_bytes` and `log_num_backups` prefs. If set in a config file, this will break scriptworker launch. I don't believe anything sets these, but bumping the major version in case.
+
+### Removed
+
 ## [4.2.0] - 2017-08-21
 ### Added
 - added `prepare_to_run_task` to create a new `current_task_info.json` in `work_dir` for easier debugging.

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -36,6 +36,7 @@ DEFAULT_CONFIG = frozendict({
     # Worker log settings
     "log_datefmt": "%Y-%m-%dT%H:%M:%S",
     "log_fmt": "%(asctime)s %(levelname)8s - %(message)s",
+    "watch_log_file": False,
 
     # intervals are expressed in seconds
     "artifact_expiration_hours": 24,

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -36,8 +36,6 @@ DEFAULT_CONFIG = frozendict({
     # Worker log settings
     "log_datefmt": "%Y-%m-%dT%H:%M:%S",
     "log_fmt": "%(asctime)s %(levelname)8s - %(message)s",
-    "log_max_bytes": 1024 * 1024 * 512,
-    "log_num_backups": 10,
 
     # intervals are expressed in seconds
     "artifact_expiration_hours": 24,

--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -52,7 +52,13 @@ def update_logging_config(context, log_name=None, file_name='worker.log'):
     # Rotating log file
     makedirs(context.config['log_dir'])
     path = os.path.join(context.config['log_dir'], file_name)
-    handler = logging.handlers.RotatingFileHandler(path)
+    if context.config["watch_log_file"]:
+        # If we rotate the log file via logrotate.d, let's watch the file
+        # so we can automatically close/reopen on move.
+        handler = logging.handlers.WatchedFileHandler(path)
+    else:
+        # Avoid using WatchedFileHandler during scriptworker unittests
+        handler = logging.FileHandler(path)
     handler.setFormatter(formatter)
     top_level_logger.addHandler(handler)
     top_level_logger.addHandler(logging.NullHandler())

--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -51,11 +51,6 @@ def update_logging_config(context, log_name=None, file_name='worker.log'):
 
     # Rotating log file
     makedirs(context.config['log_dir'])
-    path = os.path.join(context.config['log_dir'], file_name)
-    handler = logging.handlers.RotatingFileHandler(
-        path, maxBytes=context.config['log_max_bytes'],
-        backupCount=context.config['log_num_backups'],
-    )
     handler.setFormatter(formatter)
     top_level_logger.addHandler(handler)
     top_level_logger.addHandler(logging.NullHandler())

--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -52,6 +52,7 @@ def update_logging_config(context, log_name=None, file_name='worker.log'):
     # Rotating log file
     makedirs(context.config['log_dir'])
     path = os.path.join(context.config['log_dir'], file_name)
+    handler = logging.handlers.RotatingFileHandler(path)
     handler.setFormatter(formatter)
     top_level_logger.addHandler(handler)
     top_level_logger.addHandler(logging.NullHandler())

--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -51,6 +51,9 @@ def update_logging_config(context, log_name=None, file_name='worker.log'):
 
     # Rotating log file
     makedirs(context.config['log_dir'])
+    path = os.path.join(context.config['log_dir'], file_name)
+    handler.setFormatter(formatter)
+    top_level_logger.addHandler(handler)
     top_level_logger.addHandler(logging.NullHandler())
 
 

--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -51,8 +51,6 @@ def update_logging_config(context, log_name=None, file_name='worker.log'):
 
     # Rotating log file
     makedirs(context.config['log_dir'])
-    handler.setFormatter(formatter)
-    top_level_logger.addHandler(handler)
     top_level_logger.addHandler(logging.NullHandler())
 
 

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (4, 2, 0)
+__version__ = (5, 0, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
-        4, 
-        2, 
+        5,
+        0,
         0
-    ], 
-    "version_string": "4.2.0"
+    ],
+    "version_string": "5.0.0"
 }


### PR DESCRIPTION
We may be leaving behind open filehandles to the `logrotate.d` files. This should be cleaner.

@kmoir - These are your patches + mine; yours lgtm. Do you feel comfortable reviewing this? I hope I didn't step on your toes when I added a patch - the intent was to help, not take over.

- removes log rotation prefs
- switches `RotatingFileHandler` for `WatchedFileHandler` (prod) or `FileHandler` (scriptworker unit tests). We'll need to set `watch_log_file` to True in [puppet](https://hg.mozilla.org/build/puppet/file/tip/modules/scriptworker/templates/scriptworker.yaml.erb#l31).
- closes test logging filehandles after the tests run, so we don't run into similar problems while running scriptworker unit tests.