### PR TITLE
add decision 0.1.10 + comments

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -100,11 +100,18 @@ DEFAULT_CONFIG = frozendict({
     # docker image shas
     "docker_image_allowlists": frozendict({
         "decision": (
+            # 0.1.6
             "sha256:31035ed23eba3ede02b988be39027668d965b9fc45b74b932b2338a4e7936cf9",
+            # 0.1.5
             "sha256:7320c720c770e9f93df26f7da742db72b334b7ded77539fb240fc4a28363de5a",
+            # 0.1.7
             "sha256:9db282317340838f0015335d74ed56c4ee0dbad588be33e6999928a181548587",
+            # 0.1.8
             "sha256:a22b90c7e16191a701760ef4f9159e86289ba598bf8ff5b22b7b94867530460d",
+            # 0.1.9
             "sha256:d29a75b7bf6a00df12964bc1ada203c64700be3cc00836a2c016e30603ebe9e2",
+            # 0.1.10
+            "sha256:ab5127144973f6370b139a666c9431b2eaac0d03951e9cef1043468f3b03877c",
         ),
         "docker-image": (
             "sha256:74c5a18ce1768605ce9b1b5f009abac1ff11b55a007e2d03733cd6e95847c747",


### PR DESCRIPTION
Update the defaults, so scriptworker instances set up outside puppet can still verify CoT.