### PR TITLE
Bug 1394242 Support for partials CoT

### DIFF
--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -333,6 +333,7 @@ def get_valid_task_types():
         'docker-image': verify_docker_image_task,
         'pushapk': verify_pushapk_task,
         'signing': verify_signing_task,
+        'partials': verify_partials_task,
     })
 
 
@@ -984,6 +985,23 @@ async def verify_docker_image_task(chain, link):
 # verify_balrog_task {{{1
 async def verify_balrog_task(chain, obj):
     """Verify the balrog trust object.
+
+    Currently the only check is to make sure it was run on a scriptworker.
+
+    Args:
+        chain (ChainOfTrust): the chain we're operating on
+        obj (ChainOfTrust or LinkOfTrust): the trust object for the balrog task.
+
+    Raises:
+        CoTError: on error.
+
+    """
+    return await verify_scriptworker_task(chain, obj)
+
+
+# verify_partials_task {{{1
+async def verify_partials_task(chain, obj):
+    """Verify the partials trust object.
 
     Currently the only check is to make sure it was run on a scriptworker.
 

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -915,7 +915,7 @@ async def test_verify_docker_image_task_command(chain, docker_image_link):
 # verify_scriptworker_task {{{1
 @pytest.mark.parametrize("func", ["verify_balrog_task", "verify_beetmover_task",
                                   "verify_pushapk_task", "verify_signing_task",
-                                  "verify_scriptworker_task"])
+                                  "verify_partials_task", "verify_scriptworker_task"])
 @pytest.mark.asyncio
 async def test_verify_scriptworker_task(chain, build_link, func):
     build_link.worker_impl = 'scriptworker'


### PR DESCRIPTION
Currently getting 

    scriptworker.exceptions.CoTError: 'Invalid task type for signing:partials!'

This patch should add partials to the valid task types for CoT support.