### PR TITLE
bug 1396517 - don't add a decision task's decision task to cot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.1.4] - 2017-09-06
+## Fixed
+- no longer add a decision task's decision task to the chain of trust to verify. This was a regression.
+
+## Removed
+- cleaned up aurora references from everything but pushapk, which uses it.
+
 ## [5.1.3] - 2017-09-01
 ### Fixed
 - specify the correct docker shas for the new docker images.

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -393,8 +393,10 @@ def test_verify_docker_image_sha_bad_allowlist(chain, build_link, decision_link,
         cotverify.verify_docker_image_sha(chain, decision_link)
 
 
+# find_sorted_task_dependencies{{{1
 @pytest.mark.parametrize("task,expected,task_type", ((
-    {'taskGroupId': 'task_id', 'extra': {}, 'payload': {}},
+    # Make sure we don't follow other_task_id on a decision task
+    {'taskGroupId': 'other_task_id', 'extra': {}, 'payload': {}},
     [('decision:decision', 'task_id')],
     'decision'
 ), (


### PR DESCRIPTION
The current assumption is decision tasks should be standalone and
verifiable as-is. This is fallout from
https://github.com/mozilla-releng/scriptworker/commit/0356bbb4b8e73c9af4d8a2ca7eec4e88cc0b97a6#diff-340a1f42e56ecb68f523d2badfa58686L513 .

I was able to run `verify_cot` against the failing fennec signing task
and its decision task; they now pass.