### PR TITLE
bug 1393277 - cot-verifiable action/parent tasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.2.0] - 2017-10-03
+### Added
+- `scriptworker.task.get_parent_task_id` to support the new `task.extra.parent` breadcrumb.
+- `scriptworker.cot.verify.ACTION_MACH_COMMANDS` and `cot.verify.PARENT_TASK_TYPES` to separate action task verification from decision task verification.
+- `scriptworker.cot.verify.ChainOfTrust.parent_task_id` to find the `parent_task_id` later.
+- `scriptworker.cot.verify.LinkOfTrust.parent_task_id` to find the `parent_task_id` later.
+- added a new `action` task type. This uses the same sha allowlist as the `decision` task type.
+- `scriptworker.cot.verify.is_action`, since differentiating between a decision task and an action task requires some task definition introspection.
+- `verify_firefox_decision_command` now takes a `mach_commands` kwarg; for action tasks, we set this to `ACTION_MACH_COMMANDS`
+- `verify_action_task` verifies the action task command.
+- `verify_parent_task` runs the checks previously in `verify_decision_task`; we run this for both action and decision tasks.
+
+### Changed
+- `find_sorted_task_dependencies` now uses the `parent_task_id` rather than the `decision_task_id` for its `parent_tuple`.
+- `download_firefox_cot_artifacts` now downloads `task-graph.json` from action tasks as well as decision tasks
+- `verify_decision_task` now only checks the command. The other checks have been moved to `verify_parent_task`.
+- decision tasks now run `verify_parent_task`.
+
+### Fixed
+- Updated `README.md` to specify `tox` rather than `python setup.py test`
+
 ## [5.1.5] - 2017-10-02
 ### Added
 - added maple to the list of privileged branches.

--- a/README.rst
+++ b/README.rst
@@ -40,9 +40,9 @@ Testing
 
 Note: GPG tests require gpg 2.0.x!
 
-Without integration tests,
+Without integration tests, install tox, then
 
-``NO_TESTS_OVER_WIRE=1 python setup.py test``
+``NO_TESTS_OVER_WIRE=1 tox -e py35``
 
 With integration tests, first create a client with the ``assume:project:taskcluster:worker-test-scopes`` scope.
 
@@ -62,7 +62,7 @@ Then  create a ``./secrets.json`` or ``~/.scriptworker`` that looks like::
 
 then
 
-``python setup.py test``
+``tox``
 
 It's also possible to create a ``./secrets.json`` as above, then::
 

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -538,6 +538,7 @@ def verify_docker_image_sha(chain, link):
         # Using downloaded image from docker hub
         task_type = link.task_type
         image_hash = cot['environment']['imageHash']
+        # Use the decision docker_image_allowlist for action tasks.
         if task_type == 'action':
             task_type = 'decision'
         if image_hash not in link.context.config['docker_image_allowlists'][task_type]:
@@ -1061,8 +1062,8 @@ async def verify_parent_task(chain, link):
     Action task verification is currently in the same verification function as
     decision tasks, because sometimes we'll have an action task masquerading as
     a decision task, e.g. in templatized actions for release graphs. To make
-    sure our guess of decision or action task isn't fatal, call this function
-    first, and then use ``is_action()`` to determine whether to call
+    sure our guess of decision or action task isn't fatal, we call this
+    function; this function uses ``is_action()`` to determine whether to call
     ``verify_decision_task`` or ``verify_action_task``.
 
     Args:

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -538,8 +538,8 @@ def verify_docker_image_sha(chain, link):
         # Using downloaded image from docker hub
         task_type = link.task_type
         image_hash = cot['environment']['imageHash']
-        # XXX we will need some way to allow trusted developers to update these
-        # allowlists
+        if task_type == 'action':
+            task_type = 'decision'
         if image_hash not in link.context.config['docker_image_allowlists'][task_type]:
             errors.append("{} {} docker imageHash {} not in the allowlist!\n{}".format(
                 link.name, link.task_id, image_hash, cot

--- a/scriptworker/task.py
+++ b/scriptworker/task.py
@@ -70,14 +70,34 @@ def get_run_id(claim_task):
 def get_decision_task_id(task):
     """Given a task dict, return the decision taskId.
 
+    By convention, the decision task of the ``taskId`` is the task's ``taskGroupId``.
+
     Args:
         task (dict): the task dict.
 
     Returns:
-        str: the taskId.
+        str: the taskId of the decision task.
 
     """
     return task['taskGroupId']
+
+
+# get_parent_task_id {{{1
+def get_parent_task_id(task):
+    """Given a task dict, return the parent taskId.
+
+    The parent taskId could be a decision taskId, or an action taskId.
+    The parent is the task that created this task; it should have a
+    ``task-graph.json`` containing this task's definition as an artifact.
+
+    Args:
+        task (dict): the task dict
+
+    Returns:
+        str: the taskId of the parent.
+
+    """
+    return task.get('extra', {}).get('parent', get_decision_task_id(task))
 
 
 # get_worker_type {{{1

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -310,6 +310,25 @@ def test_is_try(task):
 ), (
     {
         'payload': {
+        },
+        'extra': {
+            'action': {
+            }
+        },
+    },
+    True
+), (
+    {
+        'payload': {
+            'env': {
+                'ACTION_CALLBACK': 'foo'
+            }
+        },
+    },
+    True
+), (
+    {
+        'payload': {
             'env': {
                 'GECKO_HEAD_REPOSITORY': "https://hg.mozilla.org/try/blahblah"
             }

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -451,6 +451,9 @@ def test_verify_docker_image_sha(chain, build_link, decision_link, docker_image_
     chain.links = [build_link, decision_link, docker_image_link]
     for link in chain.links:
         cotverify.verify_docker_image_sha(chain, link)
+    # cover action == decision case
+    decision_link.task_type = 'action'
+    cotverify.verify_docker_image_sha(chain, decision_link)
 
 
 def test_verify_docker_image_sha_wrong_built_sha(chain, build_link, decision_link, docker_image_link):

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -106,6 +106,7 @@ def build_link(chain):
                     'docker-image': 'docker_image_task_id',
                 },
             },
+            'parent': 'decision_task_id',
         },
     }
     yield link
@@ -133,6 +134,66 @@ def decision_link(chain):
             'image': "blah",
         },
         'extra': {},
+    }
+    yield link
+
+
+@pytest.yield_fixture(scope='function')
+def action_link(chain):
+    link = cotverify.LinkOfTrust(chain.context, 'action', 'action_task_id')
+    link.cot = {
+        'taskId': 'action_task_id',
+        'environment': {
+            'imageHash': "sha256:decision_image_sha",
+        },
+    }
+    link.task = {
+        'taskGroupId': 'decision_task_id',
+        'schedulerId': 'scheduler_id',
+        'provisionerId': 'provisioner_id',
+        'workerType': 'workerType',
+        'scopes': [],
+        'metadata': {
+            'source': 'https://hg.mozilla.org/mozilla-central',
+        },
+        'payload': {
+            'image': "blah",
+        },
+        'extra': {
+            'action': {},
+            'parent': 'decision_task_id',
+        },
+    }
+    yield link
+
+
+@pytest.yield_fixture(scope='function')
+def release_action_link(chain):
+    # Release action tasks look like decision tasks (self-contained graph) but
+    # are action tasks.
+    link = cotverify.LinkOfTrust(chain.context, 'decision', 'relaction_task_id')
+    link.cot = {
+        'taskId': 'relaction_task_id',
+        'environment': {
+            'imageHash': "sha256:decision_image_sha",
+        },
+    }
+    link.task = {
+        'taskGroupId': 'relaction_task_id',
+        'schedulerId': 'scheduler_id',
+        'provisionerId': 'provisioner_id',
+        'workerType': 'workerType',
+        'scopes': [],
+        'metadata': {
+            'source': 'https://hg.mozilla.org/mozilla-central',
+        },
+        'payload': {
+            'image': "blah",
+        },
+        'extra': {
+            'action': {},
+            'parent': 'decision_task_id',
+        },
     }
     yield link
 
@@ -230,6 +291,36 @@ def test_chain_is_try(chain, bools, expected):
 ))
 def test_is_try(task):
     assert cotverify.is_try(task)
+
+
+# is_action {{{1
+@pytest.mark.parametrize("task,expected", ((
+    {
+        'payload': {
+            'env': {
+                'ACTION_CALLBACK': 'foo'
+            }
+        },
+        'extra': {
+            'action': {
+            }
+        },
+    },
+    True
+), (
+    {
+        'payload': {
+            'env': {
+                'GECKO_HEAD_REPOSITORY': "https://hg.mozilla.org/try/blahblah"
+            }
+        },
+        'metadata': {},
+        'schedulerId': "x"
+    },
+    False
+)))
+def test_is_action(task, expected):
+    assert cotverify.is_action(task) == expected
 
 
 # get_link {{{1
@@ -402,6 +493,10 @@ def test_verify_docker_image_sha_bad_allowlist(chain, build_link, decision_link,
 ), (
     {'taskGroupId': 'decision_task_id', 'extra': {}, 'payload': {}},
     [('build:decision', 'decision_task_id')],
+    'build'
+), (
+    {'taskGroupId': 'decision_task_id', 'extra': {'parent': 'action_task_id'}, 'payload': {}},
+    [('build:action', 'action_task_id')],
     'build'
 ), (
     {
@@ -843,32 +938,36 @@ def test_verify_firefox_decision_command(decision_link, command, raises):
         cotverify.verify_firefox_decision_command(decision_link)
 
 
-# verify_decision_task {{{1
+# verify_parent_task {{{1
 @pytest.mark.asyncio
-async def test_verify_decision_task(chain, decision_link, build_link, mocker):
+async def test_verify_parent_task(chain, action_link, release_action_link,
+                                  decision_link, build_link, mocker):
+    for parent_link in (action_link, release_action_link, decision_link):
+        build_link.decision_task_id = parent_link.decision_task_id
+        build_link.parent_task_id = parent_link.task_id
 
-    def task_graph(*args, **kwargs):
-        return {
-            build_link.task_id: {
-                'task': deepcopy(build_link.task)
-            },
-            chain.task_id: {
-                'task': deepcopy(chain.task)
-            },
-        }
+        def task_graph(*args, **kwargs):
+            return {
+                build_link.task_id: {
+                    'task': deepcopy(build_link.task)
+                },
+                chain.task_id: {
+                    'task': deepcopy(chain.task)
+                },
+            }
 
-    path = os.path.join(decision_link.cot_dir, "public", "task-graph.json")
-    makedirs(os.path.dirname(path))
-    touch(path)
-    chain.links = [decision_link, build_link]
-    decision_link.task['workerType'] = chain.context.config['valid_decision_worker_types'][0]
-    mocker.patch.object(cotverify, 'load_json', new=task_graph)
-    mocker.patch.object(cotverify, 'verify_firefox_decision_command', new=noop_sync)
-    await cotverify.verify_decision_task(chain, decision_link)
+        path = os.path.join(parent_link.cot_dir, "public", "task-graph.json")
+        makedirs(os.path.dirname(path))
+        touch(path)
+        chain.links = [parent_link, build_link]
+        parent_link.task['workerType'] = chain.context.config['valid_decision_worker_types'][0]
+        mocker.patch.object(cotverify, 'load_json', new=task_graph)
+        mocker.patch.object(cotverify, 'verify_firefox_decision_command', new=noop_sync)
+        await cotverify.verify_parent_task(chain, parent_link)
 
 
 @pytest.mark.asyncio
-async def test_verify_decision_task_worker_type(chain, decision_link, build_link, mocker):
+async def test_verify_parent_task_worker_type(chain, decision_link, build_link, mocker):
 
     def task_graph(*args, **kwargs):
         return {
@@ -888,15 +987,15 @@ async def test_verify_decision_task_worker_type(chain, decision_link, build_link
     mocker.patch.object(cotverify, 'load_json', new=task_graph)
     mocker.patch.object(cotverify, 'verify_firefox_decision_command', new=noop_sync)
     with pytest.raises(CoTError):
-        await cotverify.verify_decision_task(chain, decision_link)
+        await cotverify.verify_parent_task(chain, decision_link)
 
 
 @pytest.mark.asyncio
-async def test_verify_decision_task_missing_graph(chain, decision_link, build_link, mocker):
+async def test_verify_parent_task_missing_graph(chain, decision_link, build_link, mocker):
     chain.links = [decision_link, build_link]
     decision_link.task['workerType'] = chain.context.config['valid_decision_worker_types'][0]
     with pytest.raises(CoTError):
-        await cotverify.verify_decision_task(chain, decision_link)
+        await cotverify.verify_parent_task(chain, decision_link)
 
 
 # verify_build_task {{{1
@@ -1067,6 +1166,7 @@ async def test_trace_back_to_firefox_tree_bad_cot_product(chain):
 async def test_trace_back_to_firefox_tree_unknown_repo(chain, decision_link,
                                                        build_link, docker_image_link):
     docker_image_link.decision_task_id = 'other'
+    docker_image_link.parent_task_id = 'other'
     docker_image_link.task['metadata']['source'] = "https://hg.mozilla.org/unknown/repo"
     chain.links = [decision_link, build_link, docker_image_link]
     with pytest.raises(CoTError):
@@ -1086,6 +1186,7 @@ async def test_trace_back_to_firefox_tree_docker_unknown_repo(chain, decision_li
 async def test_trace_back_to_firefox_tree_diff_repo(chain, decision_link,
                                                     build_link, docker_image_link):
     docker_image_link.decision_task_id = 'other'
+    docker_image_link.parent_task_id = 'other'
     docker_image_link.task['metadata']['source'] = "https://hg.mozilla.org/releases/mozilla-beta"
     chain.links = [decision_link, build_link, docker_image_link]
     await cotverify.trace_back_to_firefox_tree(chain)

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (5, 1, 5)
+__version__ = (5, 2, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
-        5, 
-        1, 
-        5
-    ], 
-    "version_string": "5.1.5"
+        5,
+        2,
+        0
+    ],
+    "version_string": "5.2.0"
 }


### PR DESCRIPTION
Action tasks are now full fledged graph- or subgraph- generators. This task's `task.extra.parent` points at the decision- or action- task that generated this task, so when we verify our task definition, we should look at the parent instead of the decision task. Action tasks should still check their decision task's validity; in the future we'll rebuild their task definitions from their context and the decision task's `actions.json`.

This should fix our retrigger verifications once [bug 1370343](https://bugzilla.mozilla.org/show_bug.cgi?id=1370343)  is fixed.