### PR TITLE
Refactor out delays between task executions

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -42,7 +42,7 @@ DEFAULT_CONFIG = frozendict({
     "artifact_expiration_hours": 24,
     "task_max_timeout": 60 * 20,
     "reclaim_interval": 300,
-    "poll_interval": 5,
+    "poll_interval": 10,
     "sign_key_timeout": 60 * 2,
 
     "task_script": ("bash", "-c", "echo foo && sleep 19 && exit 1"),


### PR DESCRIPTION
After some delays with beetmover executions, there's a way we can save some wall time with sequential scriptworker tasks.

Looking at task graph FvLr0IZYQiWC-OfjF-NT5Q there were between 238 and 252 tasks for each beetmoverworker.  Picking an individual beetmoverworker - number 3, the first task was at 11:40:42 and the final one started at 14:22:25, a total wall time of 2h41m43s. 

The tasks themselves are small, taking a mean of 23s. Looking further there was a mean delay between one task ending and the next beginning, of 12.28s. Not meaningful when there are a few big tasks, but with ~250 per node per release, it adds up to a wall time of roughly 51 minutes.

The main loop in the scriptworker is doing this:
 ```
if I have a task:
   do the task
   sleep(1)
sleep(5)
return
```
in the outer function, sleep(5) again, meaning that between a successful task ending and the next work being claimed, the scriptworker is sleeping for 11 seconds.

This PR adjusts that, so that the poll_interval, which controls the sleep duration, has doubled, but there's only one sleep call. The sleep also only gets called if there was no work to do. The new workflow looks like this:

try to claim a task
if no work, sleep for 10s and return
if work, do work, sleeping for 1s between tasks of there's more than one.

This means that if there's a task to do there's only a 1s sleep between it finishing and trying to get the next task - we avoid hammering the taskcluster api because the tasks themselves take longer than the poll interval. If there's no work to do, we wait a polite interval before trying again.

An optimistic estimate is that during busy times, such as all the beetmover jobs pending, we should ve able to save ~40 minutes of wall time.