### PR TITLE
don't run docker-worker tests on the chain object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- stopped verifying docker-worker cot on the chain object, which may not have a cot artifact to verify.
+- updated the `retry_exceptions` for `retry_request` to include `asyncio.TimeoutError`.
+
 ## [5.2.1] - 2017-10-11
 ### Added
 - scriptworker will now retry (`intermittent-task` status) on a script exit code of -11, which corresponds to a python segfault.

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1280,14 +1280,19 @@ async def verify_docker_worker_task(chain, link):
 
     Args:
         chain (ChainOfTrust): the chain we're operating on
-        obj (ChainOfTrust or LinkOfTrust): the trust object for the signing task.
+        link (ChainOfTrust or LinkOfTrust): the trust object for the signing task.
 
     Raises:
         CoTError: on failure.
 
     """
-    check_interactive_docker_worker(link)
-    verify_docker_image_sha(chain, link)
+    if chain != link:
+        # These two checks will die on `link.cot` if `link` is a ChainOfTrust
+        # object (e.g., the task we're running `verify_cot` against is a
+        # docker-worker task). So only run these tests if they are not the chain
+        # object.
+        check_interactive_docker_worker(link)
+        verify_docker_image_sha(chain, link)
 
 
 # verify_generic_worker_task {{{1
@@ -1296,7 +1301,7 @@ async def verify_generic_worker_task(chain, link):
 
     Args:
         chain (ChainOfTrust): the chain we're operating on
-        obj (ChainOfTrust or LinkOfTrust): the trust object for the signing task.
+        link (ChainOfTrust or LinkOfTrust): the trust object for the signing task.
 
     Raises:
         CoTError: on failure.

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -1109,9 +1109,17 @@ async def test_verify_task_types(chain, decision_link, build_link, docker_image_
 # verify_docker_worker_task {{{1
 @pytest.mark.asyncio
 async def test_verify_docker_worker_task(mocker):
-    mocker.patch.object(cotverify, 'check_interactive_docker_worker', new=noop_sync)
-    mocker.patch.object(cotverify, 'verify_docker_image_sha', new=noop_sync)
-    await cotverify.verify_docker_worker_task(mock.MagicMock(), mock.MagicMock())
+    chain = mock.MagicMock()
+    link = mock.MagicMock()
+    check = mock.MagicMock()
+    mocker.patch.object(cotverify, 'check_interactive_docker_worker', new=check.method1)
+    mocker.patch.object(cotverify, 'verify_docker_image_sha', new=check.method2)
+    await cotverify.verify_docker_worker_task(chain, chain)
+    check.method1.assert_not_called()
+    check.method2.assert_not_called()
+    await cotverify.verify_docker_worker_task(chain, link)
+    check.method1.assert_called_once_with(link)
+    check.method2.assert_called_once_with(chain, link)
 
 
 # verify_generic_worker_task {{{1


### PR DESCRIPTION
@MihaiTabara this is another one you can look at :) No rush on any of these.

`verify_cot` breaks when run against a docker-worker task, because we
try to verify chain.cot for docker-worker specific info. Because the
chain object is assumed to be the currently running task, we don't
create a cot object for it.

I ran into this while testing

```
verify_cot --task-type l10n --cleanup -- Tz_iPxtTRqCLBg64rHK8uQ
```