### PR TITLE
Bump 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.0.0] - 2018-01-03
+### Added
+- `scriptworker.cot.verify.download_cot` now supports optional upstream artifacts
+- `scriptworker.artifacts.get_optional_artifacts_per_task_id`, `scriptworker.cot.verify.(is_task_required_by_any_mandatory_artifact, is_artifact_optional)`, and `scriptworker.utils.(get_results_and_future_exceptions, add_enumerable_item_to_dict)` are defined and publicly exposed.
+
+### Changed
+- `scriptworker.artifacts.get_upstream_artifacts_full_paths_per_task_id` returns 2 dictionaries instead of 1.
+- `scriptworker.cot.verify.(verify_docker_image_sha, download_cot_artifact)` don't error out if cot isn't defined (missing cot are detected earlier)
+
 ## [5.2.3] - 2017-10-20
 ### Fixed
 - Made the exit status more explicit on exit code -11.

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (5, 2, 3)
+__version__ = (6, 0, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
-        5,
-        2,
-        3
+        6,
+        0,
+        0
     ],
-    "version_string": "5.2.3"
+    "version_string": "6.0.0"
 }


### PR DESCRIPTION
I just landed #169. I see #170 is ready too (but not #171). I don't mind if 6.0.0 includes #170. However, the changes there don't require a major version bump, so we can easily release 6.1.0 right after. @escapewindow, @tomprince, what do you guys think? 