### PR TITLE
bug 1431110 - allow for default `max_chain_length` of 20.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.0.2] - 2018-01-17
+### Added
+- `max_chain_length` pref, defaulting to the arbitrary (but larger than the current 5) int 20.
+
+### Changed
+- Stopped hardcoding the max chain length to 5 due to longer-than-5 valid chains in production.
+
 ## [6.0.1] - 2018-01-03
 ### Added
 - Allow projects/birch to use project:releng:signing:cert:release-signing

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -64,6 +64,7 @@ DEFAULT_CONFIG = frozendict({
     "verify_cot_signature": False,
     "cot_job_type": "unknown",  # e.g., signing
     "cot_product": "firefox",
+    "max_chain_length": 20,
 
     # Specify a default gpg home other than ~/.gnupg
     "gpg_home": None,

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -630,7 +630,7 @@ async def build_task_dependencies(chain, task, name, my_task_id):
 
     """
     log.info("build_task_dependencies {} {}".format(name, my_task_id))
-    if name.count(':') > 5:
+    if name.count(':') > chain.context.config['max_chain_length']:
         raise CoTError("Too deep recursion!\n{}".format(name))
     sorted_dependencies = find_sorted_task_dependencies(task, name, my_task_id)
 

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -629,7 +629,11 @@ async def test_build_task_dependencies(chain, mocker, event_loop):
 
     mocker.patch.object(cotverify, 'find_sorted_task_dependencies', new=fake_find)
     with pytest.raises(CoTError):
-        await cotverify.build_task_dependencies(chain, {}, 'too:many:colons:in:this:name:z', 'task_id')
+        await cotverify.build_task_dependencies(
+            chain, {},
+            ':'.join([str(x) for x in range(0, chain.context.config['max_chain_length'])]),
+            'task_id',
+        )
     with pytest.raises(CoTError):
         await cotverify.build_task_dependencies(chain, {}, 'build', 'task_id')
 

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -632,7 +632,10 @@ async def test_build_task_dependencies(chain, mocker, event_loop):
         length = chain.context.config['max_chain_length']
         await cotverify.build_task_dependencies(
             chain, {},
-            ':'.join([str(x) for x in range(-length, length)]),
+            # range(0, length) gives `max_chain_length` parts, but we're
+            # measuring colons which are at `max_chain_length - 1`.
+            # To go over, we have to add 2.
+            ':'.join([str(x) for x in range(0, length + 2)]),
             'task_id',
         )
     with pytest.raises(CoTError):

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -629,9 +629,10 @@ async def test_build_task_dependencies(chain, mocker, event_loop):
 
     mocker.patch.object(cotverify, 'find_sorted_task_dependencies', new=fake_find)
     with pytest.raises(CoTError):
+        length = chain.context.config['max_chain_length']
         await cotverify.build_task_dependencies(
             chain, {},
-            ':'.join([str(x) for x in range(0, chain.context.config['max_chain_length'])]),
+            ':'.join([str(x) for x in range(-length, length)]),
             'task_id',
         )
     with pytest.raises(CoTError):

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (6, 0, 1)
+__version__ = (6, 0, 2)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
-        6, 
-        0, 
-        1
-    ], 
-    "version_string": "6.0.1"
+        6,
+        0,
+        2
+    ],
+    "version_string": "6.0.2"
 }


### PR DESCRIPTION
Way back in the day, I decided no chain of trust should need to be longer than 5 tasks in length; any longer and it was a sign of a DOS attack or misconfiguration.

In https://bugzilla.mozilla.org/show_bug.cgi?id=1431110 we're seeing new valid tasks that have chains of 7? in length.

This patch makes the `max_chain_length` configurable, and sets it to a default of 20 for now.

With this patch, `verify_cot --task-type balrog --cleanup -- HDb0RySlTluYbmzopHjg-w` works. Without it, it breaks on `Too deep recursion`.