### PR TITLE
Freeze aiohttp to 2.x.y

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-aiohttp>=2.0.0
+aiohttp>=2.0.0,<3
 arrow
 defusedxml
 dictdiffer

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if {'register', 'upload'}.intersection(set(sys.argv)):
     sys.exit(1)
 
 reqs = [
-    "aiohttp>=2.0.0",
+    "aiohttp>=2.0.0,<3",
     "arrow",
     "defusedxml",
     "dictdiffer",


### PR DESCRIPTION
aiohttp 3.0.0 was [released yesterday](https://github.com/aio-libs/aiohttp/releases/tag/v3.0.0). Scriptworker has an installation problem, because taskcluster [prevents 3.0.0 from being installed](https://github.com/taskcluster/taskcluster-client.py/pull/67).

Even if we wanted taskcluster to allow 3.0.0, we would hit this [new type of failure](https://travis-ci.org/mozilla-releng/beetmoverscript/jobs/340871448#L599).

Therefore, let's first ride the 2.x.y versions and see how we can bump it on taskcluster and *script.