### PR TITLE
Implement graceful shutdown on SIGTERM

### DIFF
--- a/scriptworker/test/test_integration.py
+++ b/scriptworker/test/test_integration.py
@@ -159,7 +159,7 @@ def test_run_successful_task(event_loop, context_function):
         with remember_cwd():
             os.chdir(os.path.dirname(context.config['work_dir']))
             status = event_loop.run_until_complete(
-                worker.run_loop(context, creds_key="integration_credentials")
+                worker.run_tasks(context, creds_key="integration_credentials")
             )
         assert status == 1
         result = event_loop.run_until_complete(
@@ -186,7 +186,7 @@ def test_run_maxtimeout(event_loop, context_function):
             os.chdir(os.path.dirname(context.config['work_dir']))
             with pytest.raises(RuntimeError):
                 event_loop.run_until_complete(
-                    worker.run_loop(context, creds_key="integration_credentials")
+                    worker.run_tasks(context, creds_key="integration_credentials")
                 )
                 # Because we're using asyncio to kill tasks in the loop,
                 # we're going to hit a RuntimeError
@@ -203,7 +203,7 @@ def test_empty_queue(event_loop, context_function):
         with remember_cwd():
             os.chdir(os.path.dirname(context.config['work_dir']))
             status = event_loop.run_until_complete(
-                worker.run_loop(context, creds_key="integration_credentials")
+                worker.run_tasks(context, creds_key="integration_credentials")
             )
         assert status is None
 

--- a/scriptworker/worker.py
+++ b/scriptworker/worker.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import os
 import sys
+import signal
 
 from scriptworker.artifacts import upload_artifacts
 from scriptworker.config import get_context_from_cmdln
@@ -26,8 +27,11 @@ from scriptworker.utils import cleanup, rm
 log = logging.getLogger(__name__)
 
 
-async def run_loop(context, creds_key="credentials"):
-    """Split this out of the async_main while loop for easier testing.
+async def run_tasks(context, creds_key="credentials"):
+    """Run any tasks returned by claimWork.
+
+    Returns the integer status of the task that was run, or None if no task was
+    run.
 
     args:
         context (scriptworker.context.Context): the scriptworker context.
@@ -77,11 +81,9 @@ async def run_loop(context, creds_key="credentials"):
 
 
 async def async_main(context):
-    """Run the main async loop.
+    """Set up and run tasks for this iteration.
 
     http://docs.taskcluster.net/queue/worker-interaction/
-
-    This is a simple loop, mainly to keep each function more testable.
 
     Args:
         context (scriptworker.context.Context): the scriptworker context.
@@ -94,7 +96,7 @@ async def async_main(context):
             os.rename(tmp_gpg_home, context.config['base_gpg_home_dir'])
         finally:
             rm_lockfile(context)
-    await run_loop(context)
+    await run_tasks(context)
 
 
 def main():


### PR DESCRIPTION
If a scriptworker gets the SIGTERM signal, it will wait for the current task (if any) to finish, and then exit.

This should allow supervisor to safely restart scriptworkers, as long as tasks can be resolved in a short time.