### PR TITLE
set artifact expiration date to task expiration date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- `create_artifact` now has a default expiration of the task expiration date.
+
+### Removed
+- removed the config for `artifact_expiration_hours`.
+
 ## [9.0.0] - 2018-02-27
 ### Added
 - added support for bouncer scriptworker

--- a/scriptworker.yaml.tmpl
+++ b/scriptworker.yaml.tmpl
@@ -28,8 +28,6 @@ worker_id: dummy-worker-myname1
 #-----------------------------------------------------------------------------------------------
 # Task configs
 #-----------------------------------------------------------------------------------------------
-artifact_expiration_hours: 24
-
 # The timeouts are in seconds.
 artifact_upload_timeout: 1200
 task_max_timeout: 1200

--- a/scriptworker/artifacts.py
+++ b/scriptworker/artifacts.py
@@ -251,17 +251,16 @@ def get_artifact_url(context, task_id, path):
 
 # get_expiration_arrow {{{1
 def get_expiration_arrow(context):
-    """Return an arrow, ``artifact_expiration_hours`` in the future from now.
+    """Return an arrow matching `context.task['expires']`.
 
     Args:
         context (scriptworker.context.Context): the scriptworker context
 
     Returns:
-        arrow: now + artifact_expiration_hours
+        arrow: `context.task['expires']`.
 
     """
-    now = arrow.utcnow()
-    return now.replace(hours=context.config['artifact_expiration_hours'])
+    return arrow.get(context.task['expires'])
 
 
 # download_artifacts {{{1

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -39,7 +39,6 @@ DEFAULT_CONFIG = frozendict({
     "watch_log_file": False,
 
     # intervals are expressed in seconds
-    "artifact_expiration_hours": 24,
     "task_max_timeout": 60 * 20,
     "reclaim_interval": 300,
     "poll_interval": 10,

--- a/scriptworker/test/test_artifacts.py
+++ b/scriptworker/test/test_artifacts.py
@@ -21,7 +21,6 @@ from . import touch, rw_context, event_loop, fake_session, fake_session_500, suc
 
 @pytest.yield_fixture(scope='function')
 def context(rw_context):
-    rw_context.config['artifact_expiration_hours'] = 1
     rw_context.config['reclaim_interval'] = 0.001
     rw_context.config['task_max_timeout'] = .1
     rw_context.config['task_script'] = ('bash', '-c', '>&2 echo bar && echo foo && exit 1')

--- a/scriptworker/test/test_integration.py
+++ b/scriptworker/test/test_integration.py
@@ -69,7 +69,6 @@ def build_config(override, basedir):
         "worker_type": "dummy-worker-{}".format(randstring),
         "worker_id": "dummy-worker-{}".format(randstring),
         'artifact_upload_timeout': 60 * 2,
-        'artifact_expiration_hours': 1,
         'gpg_home': GPG_HOME,
         "gpg_encoding": 'utf-8',
         "gpg_options": None,

--- a/scriptworker/test/test_integration.py
+++ b/scriptworker/test/test_integration.py
@@ -13,7 +13,12 @@ import pytest
 import re
 import slugid
 import tempfile
-from scriptworker.config import CREDS_FILES, read_worker_creds, get_unfrozen_copy
+from scriptworker.config import (
+    CREDS_FILES,
+    apply_product_config,
+    get_unfrozen_copy,
+    read_worker_creds,
+)
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context
 from scriptworker.cot.verify import ChainOfTrust, verify_chain_of_trust
@@ -79,6 +84,7 @@ def build_config(override, basedir):
         'reclaim_interval': 5,
         'task_script': ('bash', '-c', '>&2 echo bar && echo foo && sleep 9 && exit 1'),
         'task_max_timeout': 60,
+        'cot_product': 'firefox'
     })
     creds = read_integration_creds()
     del(config['credentials'])
@@ -86,6 +92,7 @@ def build_config(override, basedir):
         config.update(override)
     with open(os.path.join(basedir, "config.json"), "w") as fh:
         json.dump(config, fh, indent=2, sort_keys=True)
+    config = apply_product_config(config)
     return config, creds
 
 

--- a/scriptworker/test/test_task.py
+++ b/scriptworker/test/test_task.py
@@ -29,7 +29,6 @@ TIMEOUT_SCRIPT = os.path.join(os.path.dirname(__file__), "data", "long_running.p
 
 @pytest.yield_fixture(scope='function')
 def context(rw_context):
-    rw_context.config['artifact_expiration_hours'] = 1
     rw_context.config['reclaim_interval'] = 0.001
     rw_context.config['task_max_timeout'] = .1
     rw_context.config['task_script'] = ('bash', '-c', '>&2 echo bar && echo foo && exit 1')


### PR DESCRIPTION
This is what we do in-tree for docker-worker (and I think generic-worker) tasks; let's do the same in scriptworker.