### PR TITLE
new gpg key fixes

### DIFF
--- a/docs/new_instance.md
+++ b/docs/new_instance.md
@@ -6,7 +6,7 @@ We don't yet have a scriptworker provisioner, so spinning up new instances of a 
 ### gpg keypair
 If this is a chain of trust enabled scriptworker, you'll need to generate a gpg keypair.  Otherwise (dev or dep scriptworker), skip to the next step.
 
-Generate and sign a gpg keypair for cltsign@**fqdn**, per [these docs](chain_of_trust.html#adding-new-worker-gpg-keys).
+Generate and sign a gpg keypair for user@**fqdn**, per [these docs](chain_of_trust.html#adding-new-worker-gpg-keys).
 
 The pubkey will need to land in the [cot-gpg-keys repo](https://github.com/mozilla-releng/cot-gpg-keys), in the `scriptworker/valid` directory.  The keypair will need to go into puppet hiera, as specified below.
 

--- a/helper_scripts/create_gpg_keys.py
+++ b/helper_scripts/create_gpg_keys.py
@@ -65,8 +65,8 @@ for host in hosts:
     log.info("Writing to %s.{pub,sec}", name)
     for pvt in (True, False):
         key = scriptworker.gpg.export_key(gpg, fingerprint, private=pvt)
-        suffix = ".pub"
+        filename = "{}@{}.pub".format(user, host)
         if pvt:
-            suffix = ".sec"
-        with open("{}{}".format(name, suffix), "w") as fh:
+            filename = "{}.sec".format(host)
+        with open(filename, "w") as fh:
             print(key, file=fh, end='')


### PR DESCRIPTION
Got tired of renaming all the hostnames to fqdns.

We want user@fqdn.pub in cot-gpg-keys; on releng-puppet2 we want just fqdn. I compromised by naming the pub file user@fqdn.pub, and the sec file fqdn.sec.

Non-urgent.