### PR TITLE
log all scriptworker events in `verify_chain_of_trust`

### DIFF
--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1816,8 +1816,9 @@ async def verify_chain_of_trust(chain):
 
     """
     log_path = os.path.join(chain.context.config["task_log_dir"], "chain_of_trust.log")
+    scriptworker_log = logging.getLogger('scriptworker')
     with contextual_log_handler(
-        chain.context, path=log_path, log_obj=log,
+        chain.context, path=log_path, log_obj=scriptworker_log,
         formatter=AuditLogFormatter(
             fmt=chain.context.config['log_fmt'],
             datefmt=chain.context.config['log_datefmt'],


### PR DESCRIPTION
We were logging `verify_chain_of_trust` with
`scriptworker.cot.verify.log`, which is set to
`logging.getLogger(__name__)`. This meant that any scriptworker
functions outside of the scriptworker.cot.verify namespace weren't being
logged.

Now we're logging `verify_chain_of_trust` with a `scriptworker`
namespace.

Fixes #175.