### PR TITLE
allow for try syntax in comment (only first line)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [10.6.1] - 2018-04-30
+### Fixed
+- restrict compariston to  the first line of hg push comments for try
+
 ## [10.6.0] - 2018-04-26
 ### Added
 - added mozilla-esr60 to restricted branches

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1138,7 +1138,9 @@ async def _get_additional_hgpush_jsone_context(parent_link, decision_link):
     pushlog_id = list(pushlog_info['pushes'].keys())[0]
     decision_comment = get_commit_message(decision_link.task)
     push_comment = pushlog_info['pushes'][pushlog_id]['changesets'][0]['desc']
-    if decision_comment not in (' ', push_comment):
+    # try syntax uses the first line of the commit.
+    first_line = push_comment.split('\n')[0]
+    if decision_comment not in (' ', push_comment, first_line):
         raise CoTError(
             "Decision task {} comment doesn't match the push comment!\n"
             "Decision comment: \n{}\nPush comment: \n{}".format(

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1140,11 +1140,11 @@ async def _get_additional_hgpush_jsone_context(parent_link, decision_link):
     push_comment = pushlog_info['pushes'][pushlog_id]['changesets'][0]['desc']
     # try syntax uses the first line of the commit.
     first_line = push_comment.split('\n')[0]
-    if decision_comment not in (' ', push_comment, first_line):
+    if decision_comment not in (' ', first_line):
         raise CoTError(
             "Decision task {} comment doesn't match the push comment!\n"
             "Decision comment: \n{}\nPush comment: \n{}".format(
-                decision_link.name, decision_comment, push_comment
+                decision_link.name, decision_comment, first_line
             )
         )
     return {

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (10, 6, 0)
+__version__ = (10, 6, 1)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         10,
         6,
-        0
+        1
     ],
-    "version_string": "10.6.0"
+    "version_string": "10.6.1"
 }


### PR DESCRIPTION
Evidently `./mach try` now appends a "Pushed via `mach try syntax`" line to the try commit message. The net result is that the task's GECKO_COMMIT_MSG only matches the first line of the push's commit message.

Without this change, `verify_cot --cleanup --task-type decision UTeFpv0GRZ-Z0P5Fv1oBeg` falls back to cotv1. With this change, it verifies cleanly in cotv2.