### PR TITLE
Fix try comments part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [10.6.2] - 2018-05-01
+### Fixed
+- find try: in any line of an hg push comment, and strip any preceding characters
+
 ## [10.6.1] - 2018-04-30
 ### Fixed
 - restrict compariston to  the first line of hg push comments for try

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1139,11 +1139,9 @@ async def _get_additional_hgpush_jsone_context(parent_link, decision_link):
     decision_comment = get_commit_message(decision_link.task)
     push_comment = pushlog_info['pushes'][pushlog_id]['changesets'][0]['desc']
     allowed_comments = [' ']
-    # try syntax uses the first line of the commit.
-    first_line = push_comment.split('\n')[0]
-    if 'try:' in first_line:
-        parts = first_line.split('try:')
-        allowed_comments.append('try:{}'.format(parts[-1]))
+    if 'try:' in push_comment:
+        try_idx = push_comment.index('try:')
+        allowed_comments.append(push_comment[try_idx:].split('\n')[0])
     if decision_comment not in allowed_comments:
         raise CoTError(
             "Decision task {} comment doesn't match the push comment!\n"

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1138,9 +1138,13 @@ async def _get_additional_hgpush_jsone_context(parent_link, decision_link):
     pushlog_id = list(pushlog_info['pushes'].keys())[0]
     decision_comment = get_commit_message(decision_link.task)
     push_comment = pushlog_info['pushes'][pushlog_id]['changesets'][0]['desc']
+    allowed_comments = [' ']
     # try syntax uses the first line of the commit.
     first_line = push_comment.split('\n')[0]
-    if decision_comment not in (' ', first_line):
+    if 'try:' in first_line:
+        parts = first_line.split('try:')
+        allowed_comments.append('try:{}'.format(parts[-1]))
+    if decision_comment not in allowed_comments:
         raise CoTError(
             "Decision task {} comment doesn't match the push comment!\n"
             "Decision comment: \n{}\nPush comment: \n{}".format(

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1139,6 +1139,8 @@ async def _get_additional_hgpush_jsone_context(parent_link, decision_link):
     decision_comment = get_commit_message(decision_link.task)
     push_comment = pushlog_info['pushes'][pushlog_id]['changesets'][0]['desc']
     allowed_comments = [' ']
+    # try logic from
+    # https://searchfox.org/mozilla-central/rev/795575287259a370d00518098472eaa5b362bfa7/taskcluster/taskgraph/try_option_syntax.py#184-188  # noqa
     if 'try:' in push_comment:
         try_idx = push_comment.index('try:')
         allowed_comments.append(push_comment[try_idx:].split('\n')[0])
@@ -1146,7 +1148,7 @@ async def _get_additional_hgpush_jsone_context(parent_link, decision_link):
         raise CoTError(
             "Decision task {} comment doesn't match the push comment!\n"
             "Decision comment: \n{}\nPush comment: \n{}".format(
-                decision_link.name, decision_comment, first_line
+                decision_link.name, decision_comment, push_comment
             )
         )
     return {

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -1282,6 +1282,59 @@ async def test_verify_parent_task_definition_failed_tasks_for(chain, mocker):
         )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("push_comment,task_comment,raises", ((
+    'foo bar baz', ' ', False
+), (
+    'try: a b c', 'try: a b c', False
+), (
+    'blah blah blah blah try: a b c', 'try: a b c', False
+), (
+    'asdfsadfsad', '', True
+)))
+async def test_get_additional_hgpush_jsone_context(chain, mocker, push_comment,
+                                                   task_comment, raises):
+
+    async def fake_pushlog(*args):
+        return {
+            'pushes': {
+                '123': {
+                    'user': 'myuser',
+                    'date': 'mydate',
+                    'changesets': [{
+                        'desc': push_comment
+                    }]
+                }
+            }
+        }
+
+    def fake_commit_msg(*args):
+        return task_comment
+
+    mocker.patch.object(cotverify, 'get_revision', return_value="myrev")
+    mocker.patch.object(cotverify, 'get_pushlog_info', new=fake_pushlog)
+    mocker.patch.object(cotverify, 'get_commit_message', new=fake_commit_msg)
+
+    if raises:
+        with pytest.raises(CoTError):
+            await cotverify._get_additional_hgpush_jsone_context(
+                chain, chain
+            )
+    else:
+        expected = {
+            "push": {
+                "revision": "myrev",
+                "comment": task_comment,
+                "owner": "myuser",
+                "pushlog_id": "123",
+                "pushdate": "mydate",
+            }
+        }
+        assert expected == await cotverify._get_additional_hgpush_jsone_context(
+            chain, chain
+        )
+
+
 # verify_parent_task {{{1
 @pytest.mark.asyncio
 @pytest.mark.parametrize("defn_fn,min_cot_version,raises", ((

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -1290,6 +1290,8 @@ async def test_verify_parent_task_definition_failed_tasks_for(chain, mocker):
 ), (
     'blah blah blah blah try: a b c', 'try: a b c', False
 ), (
+    'blah blah blah blah\nlbah blha try: [a] b c\nblah blah', 'try: [a] b c', False
+), (
     'asdfsadfsad', '', True
 )))
 async def test_get_additional_hgpush_jsone_context(chain, mocker, push_comment,

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (10, 6, 1)
+__version__ = (10, 6, 2)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         10,
         6,
-        1
+        2
     ],
-    "version_string": "10.6.1"
+    "version_string": "10.6.2"
 }


### PR DESCRIPTION
We don't just use the first line of a comment in a try push; we trim everything before `try:`.

Without this change, `verify_cot --task-type decision --cleanup IfGymcgYRnCwGP3uR9wA9w` fails cotv2 and fails back to cotv1. With this change, `verify_cot --task-type decision --cleanup IfGymcgYRnCwGP3uR9wA9w` works.