### PR TITLE
bug 1400258 - write cot verification logs to live_backing.log

### DIFF
--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1795,7 +1795,7 @@ async def verify_chain_of_trust(chain):
         CoTError: on failure
 
     """
-    log_path = os.path.join(chain.context.config["task_log_dir"], "chain_of_trust.log")
+    log_path = os.path.join(chain.context.config["task_log_dir"], "live_backing.log")
     scriptworker_log = logging.getLogger('scriptworker')
     with contextual_log_handler(
         chain.context, path=log_path, log_obj=scriptworker_log,

--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -112,7 +112,7 @@ def get_log_filehandle(context):
     """
     log_file_name = get_log_filename(context)
     makedirs(context.config['task_log_dir'])
-    with open(log_file_name, "w", encoding="utf-8") as filehandle:
+    with open(log_file_name, "a", encoding="utf-8") as filehandle:
         yield filehandle
 
 


### PR DESCRIPTION
Fixes #179.

This writes the chain of trust verification log to `live_backing.log`, then appends the task log. I could change this to write cot verification to `live_backing.log`, then move it to `chain_of_trust.log` on success, if we prefer not to see this output in the full log.

I'm thinking we should clean up/clarify the cot log output anyway, so maybe more visibility is better.