### PR TITLE
Fix intermittent test bustage + unclosed session warnings

### DIFF
--- a/scriptworker/test/__init__.py
+++ b/scriptworker/test/__init__.py
@@ -237,20 +237,6 @@ def integration_create_task_payload(config, task_group_id, scopes=None,
 
 
 @pytest.yield_fixture(scope='function')
-def event_loop():
-    """Create an instance of the default event loop for each test case.
-    From https://github.com/pytest-dev/pytest-asyncio/issues/29#issuecomment-226947296
-
-    In general, we should use @pytest.mark.asyncio, but we sometimes need to
-    do something like kill tasks that benefits from clean event loops.
-
-    """
-    loop = asyncio.get_event_loop()
-    yield loop
-
-
-
-@pytest.yield_fixture(scope='function')
 def tmpdir():
     """Yield a tmpdir that gets cleaned up afterwards.
 

--- a/scriptworker/test/test_client.py
+++ b/scriptworker/test/test_client.py
@@ -25,7 +25,7 @@ from scriptworker.context import Context
 from scriptworker.exceptions import ScriptWorkerException, ScriptWorkerTaskException, TaskVerificationError
 from scriptworker.utils import noop_sync
 
-from . import tmpdir, event_loop
+from . import tmpdir
 
 assert tmpdir  # silence pyflakes
 
@@ -209,7 +209,7 @@ def test_bad_artifact_url(valid_artifact_rules, valid_artifact_task_ids, url):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('should_validate_task', (True, False))
-async def test_sync_main_runs_fully(config, event_loop, should_validate_task):
+async def test_sync_main_runs_fully(config, should_validate_task):
     copyfile(BASIC_TASK, os.path.join(config['work_dir'], 'task.json'))
     async_main_calls = []
     run_until_complete_calls = []

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -592,7 +592,7 @@ def test_find_sorted_task_dependencies(task, expected, task_type):
 
 # build_task_dependencies {{{1
 @pytest.mark.asyncio
-async def test_build_task_dependencies(chain, mocker, event_loop):
+async def test_build_task_dependencies(chain, mocker):
 
     async def fake_task(task_id):
         if task_id == 'die':
@@ -665,7 +665,7 @@ async def test_build_task_dependencies(chain, mocker, event_loop):
     None,
 )))
 @pytest.mark.asyncio
-async def test_download_cot(chain, mocker, event_loop, upstream_artifacts, raises, download_artifacts_mock):
+async def test_download_cot(chain, mocker, upstream_artifacts, raises, download_artifacts_mock):
     async def down(*args, **kwargs):
         return ['x']
 
@@ -702,7 +702,7 @@ async def test_download_cot(chain, mocker, event_loop, upstream_artifacts, raise
     "missing", "bad_sha", True
 )))
 @pytest.mark.asyncio
-async def test_download_cot_artifact(chain, path, sha, raises, mocker, event_loop):
+async def test_download_cot_artifact(chain, path, sha, raises, mocker):
 
     def fake_get_hash(*args, **kwargs):
         return sha
@@ -734,7 +734,7 @@ async def test_download_cot_artifact(chain, path, sha, raises, mocker, event_loo
 
 
 @pytest.mark.asyncio
-async def test_download_cot_artifact_no_downloaded_cot(chain, mocker, event_loop):
+async def test_download_cot_artifact_no_downloaded_cot(chain, mocker):
     link = mock.MagicMock()
     link.task_id = 'task_id'
     link.cot = None
@@ -757,7 +757,7 @@ async def test_download_cot_artifact_no_downloaded_cot(chain, mocker, event_loop
     False,
 )))
 @pytest.mark.asyncio
-async def test_download_cot_artifacts(chain, raises, mocker, upstreamArtifacts, event_loop):
+async def test_download_cot_artifacts(chain, raises, mocker, upstreamArtifacts):
 
     async def fake_download(x, y, path):
         if path == 'failed_path':
@@ -884,7 +884,7 @@ def test_is_artifact_optional(chain, upstream_artifacts, task_id, path, expected
 @pytest.mark.asyncio
 async def test_get_all_artifacts_per_task_id(chain, decision_link, build_link,
                                              upstream_artifacts, expected,
-                                             docker_image_link, mocker, event_loop):
+                                             docker_image_link, mocker):
 
     chain.links = [decision_link, build_link, docker_image_link]
     assert expected == cotverify.get_all_artifacts_per_task_id(chain, upstream_artifacts)

--- a/scriptworker/test/test_gpg.py
+++ b/scriptworker/test/test_gpg.py
@@ -16,10 +16,10 @@ import tarfile
 from scriptworker.exceptions import ScriptWorkerGPGException, ScriptWorkerRetryException
 import scriptworker.gpg as sgpg
 from scriptworker.utils import rm
-from . import GOOD_GPG_KEYS, BAD_GPG_KEYS, event_loop, noop_async, noop_sync, tmpdir, touch
+from . import GOOD_GPG_KEYS, BAD_GPG_KEYS, noop_async, noop_sync, tmpdir, touch
 from . import rw_context as context
 
-assert event_loop, tmpdir  # silence pyflakes
+assert tmpdir  # silence pyflakes
 assert context  # silence pyflakes
 
 
@@ -722,7 +722,7 @@ async def test_verify_signed_tag(context, mocker, valid_signed, head_rev, tag_re
 
 
 # build_gpg_homedirs_from_repo {{{1
-def test_build_gpg_homedirs_from_repo(context, mocker, event_loop):
+def test_build_gpg_homedirs_from_repo(context, mocker):
     homedirs = {'flat': [], 'signed': []}
     expected = {
         'flat': ['docker-worker', 'generic-worker'],
@@ -745,7 +745,7 @@ def test_build_gpg_homedirs_from_repo(context, mocker, event_loop):
 
 # rebuild_gpg_homedirs {{{1
 @pytest.mark.parametrize("new_rev_found", [True, False])
-def test_rebuild_gpg_homedirs(context, mocker, event_loop, new_rev_found):
+def test_rebuild_gpg_homedirs(context, mocker, new_rev_found):
     def fake_context(*args):
         return (context, None)
 
@@ -771,7 +771,7 @@ def test_rebuild_gpg_homedirs(context, mocker, event_loop, new_rev_found):
 
 
 @pytest.mark.parametrize("nuke_dir", (True, False))
-def test_rebuild_gpg_homedirs_exception(context, mocker, event_loop, nuke_dir):
+def test_rebuild_gpg_homedirs_exception(context, mocker, nuke_dir):
 
     def fake_context(*args):
         return (context, None)
@@ -793,7 +793,7 @@ def test_rebuild_gpg_homedirs_exception(context, mocker, event_loop, nuke_dir):
         sgpg.rebuild_gpg_homedirs()
 
 
-def test_rebuild_gpg_homedirs_lockfile(context, mocker, event_loop):
+def test_rebuild_gpg_homedirs_lockfile(context, mocker):
 
     def fake_context(*args):
         return (context, None)


### PR DESCRIPTION
Scriptworker tests have been flaky of late, using both pytest-asyncio and pytest-xdist with 4 parallel tests; the symptom is a bunch of tests failed with closed event loop errors. Removing the `event_loop` fixture appears to address this flakiness. I believe some \*scripts import the `event_loop` fixture; we should be able to apply similar fixes downstream. (If we don't, then the imports will fail when we release a new scriptworker with these patches. I can do a pass through the various \*scripts.)

Also, our tests have been peppered with aiohttp unclosed session warnings. I tracked these down to the `rw_context` fixture; by adding an explicit close for `context.session`, `context.queue.session`, and `context.temp_queue.session` if they exist and are `aiohttp.ClientSession` instances, we no longer have those warnings.