### PR TITLE
explicitly pass in an `event_loop` in testing.

### DIFF
--- a/scriptworker/test/__init__.py
+++ b/scriptworker/test/__init__.py
@@ -270,7 +270,7 @@ async def _close_session(obj):
 
 @pytest.mark.asyncio
 @pytest.yield_fixture(scope='function', params=['firefox'])
-async def rw_context(request):
+async def rw_context(request, event_loop):
     with tempfile.TemporaryDirectory() as tmp:
         config = get_unfrozen_copy(DEFAULT_CONFIG)
         config['cot_product'] = request.param
@@ -285,6 +285,7 @@ async def rw_context(request):
             if key.endswith("key_path") or key in ("gpg_home", ):
                 context.config[key] = os.path.join(tmp, key)
         context.config['verbose'] = VERBOSE
+        context.event_loop = event_loop
         yield context
         await _close_session(context)
         await _close_session(context.queue)

--- a/scriptworker/test/test_context.py
+++ b/scriptworker/test/test_context.py
@@ -2,7 +2,9 @@
 # coding=utf-8
 """Test scriptworker.context
 """
+import asyncio
 import json
+import mock
 import os
 import pytest
 import taskcluster
@@ -124,3 +126,23 @@ def test_get_credentials(context):
     expected = {'asdf': 'foobar'}
     context._credentials = expected
     assert context.credentials == expected
+
+
+def test_new_event_loop(mocker):
+    """The default context.event_loop is from `asyncio.get_event_loop`"""
+    fake_loop = mock.MagicMock()
+    mocker.patch.object(asyncio, 'get_event_loop', return_value=fake_loop)
+    context = swcontext.Context()
+    assert context.event_loop == fake_loop
+
+
+def test_set_event_loop(mocker):
+    """`context.event_loop` returns the same value once set.
+
+    (This may seem obvious, but this tests the correctness of the property.)
+
+    """
+    fake_loop = mock.MagicMock()
+    context = swcontext.Context()
+    context.event_loop = fake_loop
+    assert context.event_loop == fake_loop

--- a/scriptworker/test/test_context.py
+++ b/scriptworker/test/test_context.py
@@ -133,7 +133,7 @@ def test_new_event_loop(mocker):
     fake_loop = mock.MagicMock()
     mocker.patch.object(asyncio, 'get_event_loop', return_value=fake_loop)
     context = swcontext.Context()
-    assert context.event_loop == fake_loop
+    assert context.event_loop is fake_loop
 
 
 def test_set_event_loop(mocker):
@@ -145,4 +145,4 @@ def test_set_event_loop(mocker):
     fake_loop = mock.MagicMock()
     context = swcontext.Context()
     context.event_loop = fake_loop
-    assert context.event_loop == fake_loop
+    assert context.event_loop is fake_loop

--- a/scriptworker/test/test_gpg.py
+++ b/scriptworker/test/test_gpg.py
@@ -767,7 +767,7 @@ def test_rebuild_gpg_homedirs(context, mocker, new_rev_found):
     mocker.patch.object(sgpg, "build_gpg_homedirs_from_repo", new=noop_sync)
     mocker.patch.object(sgpg, "write_last_good_git_revision", new=noop_sync)
 
-    sgpg.rebuild_gpg_homedirs()
+    sgpg.rebuild_gpg_homedirs(event_loop=context.event_loop)
 
 
 @pytest.mark.parametrize("nuke_dir", (True, False))
@@ -790,7 +790,7 @@ def test_rebuild_gpg_homedirs_exception(context, mocker, nuke_dir):
     mocker.patch.object(sgpg, "build_gpg_homedirs_from_repo", new=noop_sync)
 
     with pytest.raises(SystemExit):
-        sgpg.rebuild_gpg_homedirs()
+        sgpg.rebuild_gpg_homedirs(event_loop=context.event_loop)
 
 
 def test_rebuild_gpg_homedirs_lockfile(context, mocker):
@@ -802,7 +802,7 @@ def test_rebuild_gpg_homedirs_lockfile(context, mocker):
     mocker.patch.object(sgpg, "update_logging_config", new=noop_sync)
 
     touch(context.config['gpg_lockfile'])
-    sgpg.rebuild_gpg_homedirs()
+    sgpg.rebuild_gpg_homedirs(event_loop=context.event_loop)
 
 
 # last_good_git_revision {{{1

--- a/scriptworker/test/test_worker.py
+++ b/scriptworker/test/test_worker.py
@@ -33,7 +33,7 @@ def context(rw_context):
 
 
 # main {{{1
-def test_main(mocker, context):
+def test_main(mocker, context, event_loop):
     config = dict(context.config)
     config['poll_interval'] = 1
     creds = {'fake_creds': True}
@@ -52,12 +52,12 @@ def test_main(mocker, context):
         mocker.patch.object(worker, 'async_main', new=foo)
         mocker.patch.object(sys, 'argv', new=['x', tmp])
         with pytest.raises(ScriptWorkerException):
-            worker.main()
+            worker.main(event_loop=event_loop)
     finally:
         os.remove(tmp)
 
 
-def test_main_sigterm(mocker, context):
+def test_main_sigterm(mocker, context, event_loop):
     """Test that sending SIGTERM causes the main loop to stop after the next
     call to async_main."""
     config = dict(context.config)
@@ -77,7 +77,7 @@ def test_main_sigterm(mocker, context):
         del(config['credentials'])
         mocker.patch.object(worker, 'async_main', new=async_main)
         mocker.patch.object(sys, 'argv', new=['x', tmp])
-        worker.main()
+        worker.main(event_loop=event_loop)
     finally:
         os.remove(tmp)
 


### PR DESCRIPTION
Create a `context.event_loop` property to standardize the loop we use.
In regular usage, we default to `asyncio.get_event_loop()`. In testing,
we're using `pytest-asyncio` which creates new `event_loop` fixtures per
test and closes them at the end; and `pytest-xdist` which runs tests in
parallel. When combined, bare `asyncio.get_event_loop()` calls can
result in intermittent bustage (closed loop errors).

By modifying the `rw_context` fixture to populate its `event_loop` with
the `pytest-asyncio` `event_loop`, we get most of the way to the fix.
`main` and `rebuild_gpg_homedirs` are entry points that create their own
`context` objects, so they now take optional `event_loop` kwargs to
override the loop during testing.