### PR TITLE
Bug 1483326: Don't restrict access to the -dev bouncerwork.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [15.0.2] - 2018-08-31
+### Added
+- Allow any branch access to the -dev bouncer scriptwork.
+
 ## [15.0.1] - 2018-08-31
 ### Changed
 - use `task.tags.worker-implementation` as the worker implementation, if specified.

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -225,7 +225,6 @@ DEFAULT_CONFIG = frozendict({
                 'project:releng:beetmover:bucket:release': 'all-release-branches',
 
                 'project:releng:bouncer:server:production': 'all-production-branches',
-                'project:releng:bouncer:server:staging': 'all-staging-branches',
 
                 # As part of the Dawn project we decided to use the Aurora Google Play
                 # app to ship Firefox Nightly. This means that the "nightly" trees need

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (15, 0, 1)
+__version__ = (15, 0, 2)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         15,
         0,
-        0
+        2
     ],
-    "version_string": "15.0.0"
+    "version_string": "15.0.2"
 }


### PR DESCRIPTION
Once https://github.com/mozilla-releng/build-puppet/pull/165 has landed,
the staging bouncerworker no longer has access to production credentials,
so it is safe to allow level 1 trees to run jobs on it.