### PR TITLE
Bug 1486532 - consider task['tags']['worker-implementation'] when guessing worker implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [15.0.1] - 2018-08-31
+### Changed
+- use `task.tags.worker-implementation` as the worker implementation, if specified.
+
 ## [15.0.0] - 2018-07-26
 ### Changed
 - require py37 to be green

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -325,6 +325,8 @@ def guess_worker_impl(link):
         worker_impls.append("generic-worker")
     if task['payload'].get("osGroups") is not None:
         worker_impls.append("generic-worker")
+    if task.get('tags', {}).get("worker-implementation", {}):
+        worker_impls.append(task['tags']['worker-implementation'])
 
     for scope in task['scopes']:
         if scope.startswith("docker-worker:"):

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1827,7 +1827,7 @@ async def verify_chain_of_trust(chain):
 
 
 # verify_cot_cmdln {{{1
-def verify_cot_cmdln(args=None):
+def verify_cot_cmdln(args=None, event_loop=None):
     """Test the chain of trust from the commandline, for debugging purposes.
 
     Args:
@@ -1858,14 +1858,14 @@ or in the CREDS_FILES http://bit.ly/2fVMu0A""")
     log = logging.getLogger('scriptworker')
     log.setLevel(logging.DEBUG)
     logging.basicConfig()
-    loop = asyncio.get_event_loop()
+    event_loop = event_loop or asyncio.get_event_loop()
     conn = aiohttp.TCPConnector()
     try:
         session = aiohttp.ClientSession(connector=conn)
         context = Context()
         context.session = session
         context.credentials = read_worker_creds()
-        context.task = loop.run_until_complete(context.queue.task(opts.task_id))
+        context.task = event_loop.run_until_complete(context.queue.task(opts.task_id))
         context.config = dict(deepcopy(DEFAULT_CONFIG))
         context.config.update({
             'cot_product': opts.cot_product,
@@ -1877,8 +1877,8 @@ or in the CREDS_FILES http://bit.ly/2fVMu0A""")
         })
         context.config = apply_product_config(context.config)
         cot = ChainOfTrust(context, opts.task_type, task_id=opts.task_id)
-        loop.run_until_complete(verify_chain_of_trust(cot))
-        loop.run_until_complete(context.session.close())
+        event_loop.run_until_complete(verify_chain_of_trust(cot))
+        event_loop.run_until_complete(context.session.close())
         conn.close()
         log.info(format_json(cot.dependent_task_ids()))
         log.info("{} : {}".format(cot.name, cot.task_id))

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -292,9 +292,7 @@ def raise_on_errors(errors, level=logging.CRITICAL):
 def guess_worker_impl(link):
     """Given a task, determine which worker implementation (e.g., docker-worker) it was run on.
 
-    Currently there are no task markers for taskcluster-worker.  Those need to
-    be populated here once they're ready.
-
+    * check for the `worker-implementation` tag
     * docker-worker: ``task.payload.image`` is not None
     * check for scopes beginning with the worker type name.
     * generic-worker: ``task.payload.osGroups`` is not None

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -403,6 +403,12 @@ def test_raise_on_errors(errors, raises):
 ), (
     {'payload': {'image': 'x', 'osGroups': []}, 'provisionerId': '', 'workerType': '', 'scopes': []},
     None, True
+), (
+    {'payload': {}, 'provisionerId': '', 'workerType': '', 'scopes': [], 'tags': {'worker-implementation': 'generic-worker'}},
+    'generic-worker', False
+), (
+    {'payload': {'image': 'x'}, 'provisionerId': '', 'workerType': '', 'scopes': ['docker-worker:'], 'tags': {'worker-implementation': 'generic-worker'}},
+    None, True
 )))
 def test_guess_worker_impl(chain, task, expected, raises):
     link = mock.MagicMock()

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -1716,7 +1716,7 @@ async def test_verify_chain_of_trust(chain, exc, mocker):
 
 # verify_cot_cmdln {{{1
 @pytest.mark.parametrize("args", (("x", "--task-type", "signing", "--cleanup"), ("x", "--task-type", "balrog")))
-def test_verify_cot_cmdln(chain, args, tmpdir, mocker):
+def test_verify_cot_cmdln(chain, args, tmpdir, mocker, event_loop):
     context = mock.MagicMock()
     context.queue = mock.MagicMock()
     context.queue.task = noop_async
@@ -1741,4 +1741,4 @@ def test_verify_cot_cmdln(chain, args, tmpdir, mocker):
     mocker.patch.object(cotverify, 'ChainOfTrust', new=cot)
     mocker.patch.object(cotverify, 'verify_chain_of_trust', new=noop_async)
 
-    cotverify.verify_cot_cmdln(args=args)
+    cotverify.verify_cot_cmdln(args=args, event_loop=event_loop)

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (15, 0, 0)
+__version__ = (15, 0, 1)
 __version_string__ = get_version_string(__version__)
 
 


### PR DESCRIPTION
In [bug 1486532](https://bugzil.la/1486532) empty properties in generic-worker task payloads in gecko decision task generated tasks will be disappearing. Currently, scriptworker guesses worker implementation based on properties that are included in the task payloads. Therefore, if these properties disappear, this guessing function will unfortunately no longer work. However, the good news is, there is trustworthy metadata contained in the gecko decision-task generated task definitions which provides this information, which is the `worker-implementation` tag. I suspect this didn't exist when the worker implementation guess code was written, but now that it does, it should be a reliable source of information.

I'm not sure if scriptworker evaluates tasks that are generated outside of the gecko decision task which may not have the `worker-implementation` tag, such as release tasks? Therefore, rather than assuming the presence of the `worker-implementation` tag, the previous mechanics of guessing the worker implementation have been left in place essentially as a fallback (with the added advantage that if they conflict with the tag, an exception will be raised).

Note, if the `worker-implementation` tag turns out to be present in all tasks that scriptworker evaluates, we could (and probably should) remove the former guessing code.