### PR TITLE
Bug 1473416: Allow try to talk to staging ship-it and snap workers.

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -240,10 +240,8 @@ DEFAULT_CONFIG = frozendict({
 
                 'project:releng:snapcraft:firefox:beta': 'beta',
                 'project:releng:snapcraft:firefox:candidate': 'release',
-                'project:releng:snapcraft:firefox:mock': 'all-staging-branches',
 
                 'project:releng:ship-it:production': 'all-production-branches',
-                'project:releng:ship-it:staging': 'all-staging-branches',
 
                 'project:releng:treescript:action:push': 'all-release-branches',
             }),


### PR DESCRIPTION
It looks like the `:mock` snap scope doesn't touch external resources, so no reason to limit it.