### PR TITLE
Bug 1486089 - Support "github-release" tasks_for and cron of mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [16.2.0] - 2018-10-15
+### Added
+- `rootUrl` support for `taskcluster>=5.0.0`
+- Python 3.7 dockerfile
+- support for `github-release`
+- support cron task scheduled as `github-release` in the case `cot_product == "mobile"`
+
+### Removed
+- when `cot_product == "mobile"`, json-e verification is no longer skipped
+
+### Changed
+- `test` and `gnupg` dockerfiles are now one.
+
+### Fixed
+- `verify_cot` for `taskcluster>=5.0.0`
+
 ## [16.1.0] - 2018-10-10
 ### Added
 - add `taskcluster_root_url` to support taskcluster>=5.0.0

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -369,7 +369,7 @@ DEFAULT_CONFIG = frozendict({
         'by-cot-product': frozendict({
             'firefox': 'GECKO',
             'thunderbird': 'COMM',
-            'mobile': '',   # mozilla-mobile projects are built on GitHub instead of hg.m.o
+            'mobile': 'MOBILE',
         })
     },
     'extra_run_task_arguments': {

--- a/scriptworker/task.py
+++ b/scriptworker/task.py
@@ -31,7 +31,7 @@ from scriptworker.utils import (
 
 log = logging.getLogger(__name__)
 
-KNOWN_TASKS_FOR = ('hg-push', 'cron', 'action')
+KNOWN_TASKS_FOR = ('hg-push', 'cron', 'action', 'github-release')
 REPO_SCOPE_REGEX = re.compile("^assume:repo:[^:]+:action:[^:]+$")
 
 
@@ -179,6 +179,40 @@ def get_revision(task, source_env_prefix):
     """
     revision = task['payload'].get('env', {}).get(source_env_prefix + '_HEAD_REV')
     return revision
+
+
+def get_branch(task, source_env_prefix):
+    """Get the branch on top of which the graph was made.
+
+    Args:
+        obj (ChainOfTrust or LinkOfTrust): the trust object to inspect
+        source_env_prefix (str): The environment variable prefix that is used
+            to get repository information.
+
+    Returns:
+        str: the username of the entity who triggered the graph.
+        None: if not defined for this task.
+
+    """
+    branch = task['payload'].get('env', {}).get(source_env_prefix + '_HEAD_BRANCH')
+    return branch
+
+
+def get_triggered_by(task, source_env_prefix):
+    """Get who triggered the graph.
+
+    Args:
+        obj (ChainOfTrust or LinkOfTrust): the trust object to inspect
+        source_env_prefix (str): The environment variable prefix that is used
+            to get repository information.
+
+    Returns:
+        str: the username of the entity who triggered the graph.
+        None: if not defined for this task.
+
+    """
+    triggered_by = task['payload'].get('env', {}).get(source_env_prefix + '_TRIGGERED_BY')
+    return triggered_by
 
 
 # get_worker_type {{{1

--- a/scriptworker/test/test_task.py
+++ b/scriptworker/test/test_task.py
@@ -130,6 +130,26 @@ def test_get_revision(rev):
     assert swtask.get_revision(task, 'GECKO') == rev
 
 
+@pytest.mark.parametrize("branch", (None, "some-git-branch"))
+def test_get_branch(branch):
+    task = {
+        'payload': {'env': {}}
+    }
+    if branch:
+        task['payload']['env']['MOBILE_HEAD_BRANCH'] = branch
+    assert swtask.get_branch(task, 'MOBILE') == branch
+
+
+@pytest.mark.parametrize("user", (None, "some-user"))
+def test_get_triggered_by(user):
+    task = {
+        'payload': {'env': {}}
+    }
+    if user:
+        task['payload']['env']['MOBILE_TRIGGERED_BY'] = user
+    assert swtask.get_triggered_by(task, 'MOBILE') == user
+
+
 # get_worker_type {{{1
 @pytest.mark.parametrize("task,result", (({"workerType": "one"}, "one"), ({"workerType": "two"}, "two")))
 def test_get_worker_type(task, result):

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (16, 1, 0)
+__version__ = (16, 2, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
         16,
-        1,
+        2,
         0
     ],
-    "version_string": "16.1.0"
+    "version_string": "16.2.0"
 }


### PR DESCRIPTION
I tested `verify_cot` against a signing task scheduled by:
* a cron task  https://tools.taskcluster.net/groups/fj-ZwGVcT3-eBCTJElE0KQ/tasks/TosAq2dRRI2yxw221ECStQ/details
* and a release one https://tools.taskcluster.net/groups/RfhACY0wTCGdSNu7dLwpnw/tasks/YY2vQg2YSMq97NWsGDJIhw/details

with the following command:
``` sh
verify_cot --task-type signing --cleanup --cot-product mobile -- ${signingTaskId}
```

I didn't run the script against real worker, so I made these adjustments locally: https://gist.github.com/JohanLorenzo/06d11681c400f202dc37baf584a707d6

Both scenario ran fine against the current diff. You can see what `.taskcluster.yml` looks like here: https://github.com/mozilla-mobile/focus-android/compare/master...JohanLorenzo:full-chain-of-trust

I made the choice of not defining new context parameters in the case of cron. This mean, a cron context spoofs a github-release one. This makes the code simpler on chainOfTrust and Firefox Focus already runs the same script in both cases. Please let me know if this choice is too edgy.