### PR TITLE
Aiohttp warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ show-source = True
 [pytest]
 norecursedirs = .tox .git .hg sandbox .eggs build
 python_files = test_*.py
-addopts = -vv --color=yes
+addopts = -vv --color=yes --random-order
 filterwarnings =
     ignore
     error:::scriptworker

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ show-source = True
 [pytest]
 norecursedirs = .tox .git .hg sandbox .eggs build
 python_files = test_*.py
-addopts = -vv --color=yes --random-order
+addopts = -vv --color=yes --random-order --durations=10
 filterwarnings =
     ignore
     error:::scriptworker


### PR DESCRIPTION
This is a test-focused PR, driven by the latest aiohttp deprecation warnings.

- move the bulk of the `verify_cot_cmdln` logic into an async function, which allows us to use `await` and `async with` rather than keep on calling `event_loop.run_until_complete`.
- modify `rw_context` and `mobile_rw_context` to use `async with aiohttp.ClientSession() as session:` to get rid of the rest of the aiohttp deprecation warnings.
- fix pytest-random-order with `--random-order`.
- add a slowest 10 tests measurement, with `--durations=10`.

Fixes #295.