### PR TITLE
Don't retry on 404s.

### DIFF
--- a/scriptworker/artifacts.py
+++ b/scriptworker/artifacts.py
@@ -290,8 +290,8 @@ async def download_artifacts(context, file_urls, parent_dir=None, session=None,
         list: the full paths to the files downloaded
 
     Raises:
-        scriptworker.exceptions.DownloadError: on download failure after
-            max retries.
+        scriptworker.exceptions.BaseDownloadError: on download failure after
+            any applicable retries.
 
     """
     parent_dir = parent_dir or context.config['work_dir']

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -28,7 +28,7 @@ from scriptworker.artifacts import (
 from scriptworker.config import read_worker_creds, apply_product_config
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context
-from scriptworker.exceptions import CoTError, DownloadError, ScriptWorkerGPGException
+from scriptworker.exceptions import CoTError, BaseDownloadError, ScriptWorkerGPGException
 from scriptworker.gpg import get_body, GPG
 from scriptworker.log import contextual_log_handler
 from scriptworker.task import (
@@ -591,7 +591,7 @@ async def download_cot(chain):
         chain (ChainOfTrust): the chain of trust to add to.
 
     Raises:
-        DownloadError: on failure.
+        BaseDownloadError: on failure.
 
     """
     mandatory_artifact_tasks = []
@@ -689,7 +689,7 @@ async def download_cot_artifacts(chain):
 
     Raises:
         CoTError: on chain of trust sha validation error, on a mandatory artifact
-        DownloadError: on download error on a mandatory artifact
+        BaseDownloadError: on download error on a mandatory artifact
 
     """
     upstream_artifacts = chain.task['payload'].get('upstreamArtifacts', [])
@@ -1489,7 +1489,7 @@ async def verify_parent_task(chain, link):
                 verify_link_in_task_graph(chain, link, target_link)
     try:
         await verify_parent_task_definition(chain, link)
-    except (DownloadError, KeyError) as e:
+    except (BaseDownloadError, KeyError) as e:
         raise CoTError(e)
 
 
@@ -1955,7 +1955,7 @@ async def verify_chain_of_trust(chain):
             # verify the worker_impls, e.g. docker-worker
             await verify_worker_impls(chain)
             await trace_back_to_tree(chain)
-        except (DownloadError, KeyError, AttributeError) as exc:
+        except (BaseDownloadError, KeyError, AttributeError) as exc:
             log.critical("Chain of Trust verification error!", exc_info=True)
             if isinstance(exc, CoTError):
                 raise

--- a/scriptworker/exceptions.py
+++ b/scriptworker/exceptions.py
@@ -88,8 +88,8 @@ class TaskVerificationError(ScriptWorkerTaskException):
         super().__init__(msg, exit_code=STATUSES['malformed-payload'])
 
 
-class DownloadError(ScriptWorkerTaskException):
-    """Failure in ``scriptworker.utils.download_file``.
+class BaseDownloadError(ScriptWorkerTaskException):
+    """Base class for DownloadError and Download404.
 
     Attributes:
         exit_code (int): this is set to 4 (resource-unavailable).
@@ -97,15 +97,33 @@ class DownloadError(ScriptWorkerTaskException):
     """
 
     def __init__(self, msg):
-        """Initialize DownloadError.
+        """Initialize Download404.
 
         Args:
             msg (string): the error message
 
         """
-        super(DownloadError, self).__init__(
+        super(BaseDownloadError, self).__init__(
             msg, exit_code=STATUSES['resource-unavailable']
         )
+
+
+class Download404(BaseDownloadError):
+    """404 in ``scriptworker.utils.download_file``.
+
+    Attributes:
+        exit_code (int): this is set to 4 (resource-unavailable).
+
+    """
+
+
+class DownloadError(BaseDownloadError):
+    """Failure in ``scriptworker.utils.download_file``.
+
+    Attributes:
+        exit_code (int): this is set to 4 (resource-unavailable).
+
+    """
 
 
 class CoTError(ScriptWorkerTaskException, KeyError):

--- a/scriptworker/test/test_utils.py
+++ b/scriptworker/test/test_utils.py
@@ -9,11 +9,12 @@ import pytest
 import re
 import shutil
 import tempfile
-from scriptworker.exceptions import DownloadError, ScriptWorkerException, ScriptWorkerRetryException
+from scriptworker.exceptions import DownloadError, Download404, ScriptWorkerException, ScriptWorkerRetryException
 import scriptworker.utils as utils
 from . import (
     FakeResponse,
     fake_session,
+    fake_session_404,
     fake_session_500,
     noop_async,
     tmpdir,
@@ -23,6 +24,7 @@ from . import rw_context as context
 
 assert tmpdir, context  # silence flake8
 assert fake_session, fake_session_500  # silence flake8
+assert fake_session_404  # silence flake8
 
 # constants helpers and fixtures {{{1
 # from https://github.com/SecurityInnovation/PGPy/blob/develop/tests/test_01_types.py
@@ -325,6 +327,13 @@ async def test_download_file_exception(context, fake_session_500, tmpdir):
     path = os.path.join(tmpdir, "foo")
     with pytest.raises(DownloadError):
         await utils.download_file(context, "url", path, session=fake_session_500)
+
+
+@pytest.mark.asyncio
+async def test_download_file_404(context, fake_session_404, tmpdir):
+    path = os.path.join(tmpdir, "foo")
+    with pytest.raises(Download404):
+        await utils.download_file(context, "url", path, session=fake_session_404)
 
 
 # format_json {{{1


### PR DESCRIPTION
I noticed that we were retrying 404s for downloading the currently largely nonexistent `chain-of-trust.json{,.sig}` files in #294... this means it takes us a few minutes to realize that yes, the file is in fact missing. I *think* not retrying on 404 is ok; if the file is there but we have other issues, it'll be a non-404 status.

If we think this might have larger repercussions, I can retry on `BaseDownloadError` in most cases, and override that with just `DownloadError` specifically for downloading `chain-of-trust.json{,.sig}` until we create those files across all 3 worker implementations.

What do you think, @JohanLorenzo , @tomprince ?