### PR TITLE
Refactors some functions to use a sub-set of context

### DIFF
--- a/scriptworker/client.py
+++ b/scriptworker/client.py
@@ -157,7 +157,7 @@ def sync_main(async_main, config_path=None, default_config=None,
 
     """
     context = _init_context(config_path, default_config)
-    _init_logging(context)
+    _init_logging(context.config.get('verbose'))
     if should_validate_task:
         validate_task_schema(context)
     loop = loop_function()
@@ -188,10 +188,10 @@ def _usage():
     sys.exit(1)
 
 
-def _init_logging(context):
+def _init_logging(is_verbose):
     logging.basicConfig(
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        level=logging.DEBUG if context.config.get('verbose') else logging.INFO
+        level=logging.DEBUG if is_verbose else logging.INFO
     )
     logging.getLogger('taskcluster').setLevel(logging.WARNING)
 

--- a/scriptworker/config.py
+++ b/scriptworker/config.py
@@ -240,5 +240,5 @@ def get_context_from_cmdln(args, desc="Run scriptworker"):
     )
     parsed_args = parser.parse_args(args)
     context.config, credentials = create_config(config_path=parsed_args.config_path)
-    update_logging_config(context)
+    update_logging_config(context.config)
     return context, credentials

--- a/scriptworker/context.py
+++ b/scriptworker/context.py
@@ -217,6 +217,6 @@ class Context(object):
         if force or not self.projects:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 self.projects = await load_json_or_yaml_from_url(
-                    self, self.config['project_configuration_url'],
+                    self.session, self.config['project_configuration_url'],
                     os.path.join(tmpdirname, 'projects.yml')
                 )

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -268,7 +268,7 @@ class LinkOfTrust(object):
 
     def get_artifact_full_path(self, path):
         """str: the full path where an artifact should be located."""
-        return get_single_upstream_artifact_full_path(self.context, self.task_id, path)
+        return get_single_upstream_artifact_full_path(self.context.config['work_dir'], self.task_id, path)
 
 
 # raise_on_errors {{{1
@@ -601,7 +601,7 @@ async def download_cot(chain):
     # task, and will not have a signed chain of trust artifact yet.
     for link in chain.links:
         task_id = link.task_id
-        url = get_artifact_url(chain.context, task_id, 'public/chainOfTrust.json.asc')
+        url = get_artifact_url(chain.context.queue, task_id, 'public/chainOfTrust.json.asc')
         parent_dir = link.cot_dir
         coroutine = asyncio.ensure_future(
             download_artifacts(
@@ -655,7 +655,7 @@ Skipping download of this artifact'.format(path, task_id))
 
     if path not in link.cot['artifacts']:
         raise CoTError("path {} not in {} {} chain of trust artifacts!".format(path, link.name, link.task_id))
-    url = get_artifact_url(chain.context, task_id, path)
+    url = get_artifact_url(chain.context.queue, task_id, path)
     loggable_url = get_loggable_url(url)
     log.info("Downloading Chain of Trust artifact:\n{}".format(loggable_url))
     await download_artifacts(
@@ -947,7 +947,7 @@ async def get_pushlog_info(decision_link):
     log.info("Pushlog url {}".format(pushlog_url))
     file_path = os.path.join(context.config["work_dir"], "{}_push_log.json".format(decision_link.name))
     pushlog_info = await load_json_or_yaml_from_url(
-        context, pushlog_url, file_path, overwrite=False
+        context.session, pushlog_url, file_path, overwrite=False
     )
     if len(pushlog_info['pushes']) != 1:
         log.warning("Pushlog error: expected a single push at {} but got {}!".format(
@@ -1167,7 +1167,7 @@ async def get_in_tree_template(link):
             link.name, source_url
         ))
     tmpl = await load_json_or_yaml_from_url(
-        context, source_url, os.path.join(
+        context.session, source_url, os.path.join(
             context.config["work_dir"], "{}_taskcluster.yml".format(link.name)
         )
     )

--- a/scriptworker/gpg.py
+++ b/scriptworker/gpg.py
@@ -1496,7 +1496,7 @@ def rebuild_gpg_homedirs(event_loop=None):
     """
     context, _ = get_context_from_cmdln(sys.argv[1:])
     context.event_loop = event_loop or context.event_loop
-    update_logging_config(context, file_name='rebuild_gpg_homedirs.log')
+    update_logging_config(context.config, file_name='rebuild_gpg_homedirs.log')
     log.info("rebuild_gpg_homedirs()...")
     basedir = get_tmp_base_gpg_home_dir(context)
     if is_lockfile_present(context, "rebuild_gpg_homedirs"):

--- a/scriptworker/log.py
+++ b/scriptworker/log.py
@@ -16,7 +16,7 @@ from scriptworker.utils import makedirs, to_unicode
 log = logging.getLogger(__name__)
 
 
-def update_logging_config(context, log_name=None, file_name='worker.log'):
+def update_logging_config(config, log_name=None, file_name='worker.log'):
     """Update python logging settings from config.
 
     By default, this sets the ``scriptworker`` log settings, but this will
@@ -27,7 +27,7 @@ def update_logging_config(context, log_name=None, file_name='worker.log'):
     * Add a rotating logfile from config settings.
 
     Args:
-        context (scriptworker.context.Context): the scriptworker context.
+        config (dict): the running config.
         log_name (str, optional): the name of the Logger to modify.
             If None, use the top level module ('scriptworker').
             Defaults to None.
@@ -36,11 +36,11 @@ def update_logging_config(context, log_name=None, file_name='worker.log'):
     log_name = log_name or __name__.split('.')[0]
     top_level_logger = logging.getLogger(log_name)
 
-    datefmt = context.config['log_datefmt']
-    fmt = context.config['log_fmt']
+    datefmt = config['log_datefmt']
+    fmt = config['log_fmt']
     formatter = logging.Formatter(fmt=fmt, datefmt=datefmt)
 
-    if context.config.get("verbose"):
+    if config.get("verbose"):
         top_level_logger.setLevel(logging.DEBUG)
         if len(top_level_logger.handlers) == 0:
             handler = logging.StreamHandler()
@@ -50,9 +50,9 @@ def update_logging_config(context, log_name=None, file_name='worker.log'):
         top_level_logger.setLevel(logging.INFO)
 
     # Rotating log file
-    makedirs(context.config['log_dir'])
-    path = os.path.join(context.config['log_dir'], file_name)
-    if context.config["watch_log_file"]:
+    makedirs(config['log_dir'])
+    path = os.path.join(config['log_dir'], file_name)
+    if config["watch_log_file"]:
         # If we rotate the log file via logrotate.d, let's watch the file
         # so we can automatically close/reopen on move.
         handler = logging.handlers.WatchedFileHandler(path)

--- a/scriptworker/test/test_client.py
+++ b/scriptworker/test/test_client.py
@@ -314,13 +314,10 @@ def test_usage(capsys, monkeypatch):
     (False, logging.INFO),
 ))
 def test_init_logging(monkeypatch, is_verbose, log_level):
-    context = MagicMock()
-    context.config = {'verbose': is_verbose}
-
     basic_config_mock = MagicMock()
 
     monkeypatch.setattr(logging, 'basicConfig', basic_config_mock)
-    client._init_logging(context)
+    client._init_logging(is_verbose)
 
     basic_config_mock.assert_called_once_with(
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -39,8 +39,8 @@ COTV2_DIR = os.path.join(os.path.dirname(__file__), "data", "cotv2")
 COTV4_DIR = os.path.join(os.path.dirname(__file__), "data", "cotv4")
 
 
-def write_artifact(context, task_id, path, contents):
-    path = get_single_upstream_artifact_full_path(context, task_id, path)
+def write_artifact(work_dir, task_id, path, contents):
+    path = get_single_upstream_artifact_full_path(work_dir, task_id, path)
     os.makedirs(os.path.dirname(path))
     with open(path, 'w') as f:
         f.write(contents)
@@ -1405,7 +1405,7 @@ async def test_no_match_in_actions_json(chain):
     }
 
     decision_link = cotverify.LinkOfTrust(chain.context, 'decision', decision_task_id)
-    write_artifact(chain.context, decision_task_id, 'public/actions.json', json.dumps(
+    write_artifact(chain.context.config['work_dir'], decision_task_id, 'public/actions.json', json.dumps(
         {
             'actions': [
                 {
@@ -1462,7 +1462,7 @@ async def test_unknown_action_kind(chain):
     }
 
     decision_link = cotverify.LinkOfTrust(chain.context, 'decision', decision_task_id)
-    write_artifact(chain.context, decision_task_id, 'public/actions.json', json.dumps(
+    write_artifact(chain.context.config['work_dir'], decision_task_id, 'public/actions.json', json.dumps(
         {
             'actions': [
                 {

--- a/scriptworker/test/test_log.py
+++ b/scriptworker/test/test_log.py
@@ -67,7 +67,7 @@ async def test_pipe_to_log(context):
 
 def test_update_logging_config_verbose(context):
     context.config['verbose'] = True
-    swlog.update_logging_config(context, log_name=context.config['log_dir'])
+    swlog.update_logging_config(context.config, log_name=context.config['log_dir'])
     log = logging.getLogger(context.config['log_dir'])
     assert log.level == logging.DEBUG
     assert len(log.handlers) == 3
@@ -79,7 +79,7 @@ def test_update_logging_config_verbose_existing_handler(context):
     log.addHandler(logging.NullHandler())
     log.addHandler(logging.NullHandler())
     context.config['verbose'] = True
-    swlog.update_logging_config(context, log_name=context.config['log_dir'])
+    swlog.update_logging_config(context.config, log_name=context.config['log_dir'])
     assert log.level == logging.DEBUG
     assert len(log.handlers) == 4
     close_handlers(log_name=context.config['log_dir'])
@@ -87,14 +87,14 @@ def test_update_logging_config_verbose_existing_handler(context):
 
 def test_update_logging_config_not_verbose(context):
     context.config['verbose'] = False
-    swlog.update_logging_config(context, log_name=context.config['log_dir'])
+    swlog.update_logging_config(context.config, log_name=context.config['log_dir'])
     log = logging.getLogger(context.config['log_dir'])
     assert log.level == logging.INFO
     assert len(log.handlers) == 2
     close_handlers(log_name=context.config['log_dir'])
 
 
-def test_contextual_log_handler(context, mocker):
+def test_contextual_log_handler(context):
     contextual_path = os.path.join(context.config['artifact_dir'], "test.log")
     swlog.log.setLevel(logging.DEBUG)
     with swlog.contextual_log_handler(context, path=contextual_path):
@@ -109,7 +109,7 @@ def test_contextual_log_handler(context, mocker):
 def test_watched_log_file(context):
     context.config['watch_log_file'] = True
     context.config["log_fmt"] = "%(levelname)s - %(message)s"
-    swlog.update_logging_config(context, log_name=context.config['log_dir'])
+    swlog.update_logging_config(context.config, log_name=context.config['log_dir'])
     path = os.path.join(context.config['log_dir'], 'worker.log')
     log = logging.getLogger(context.config['log_dir'])
     log.info("foo")

--- a/scriptworker/test/test_utils.py
+++ b/scriptworker/test/test_utils.py
@@ -314,26 +314,26 @@ def test_rm_dir():
 
 # download_file {{{1
 @pytest.mark.asyncio
-async def test_download_file(context, fake_session, tmpdir):
+async def test_download_file(fake_session, tmpdir):
     path = os.path.join(tmpdir, "foo")
-    await utils.download_file(context, "url", path, session=fake_session)
+    await utils.download_file(fake_session, "url", path)
     with open(path, "r") as fh:
         contents = fh.read()
     assert contents == "asdfasdf"
 
 
 @pytest.mark.asyncio
-async def test_download_file_exception(context, fake_session_500, tmpdir):
+async def test_download_file_exception(fake_session_500, tmpdir):
     path = os.path.join(tmpdir, "foo")
     with pytest.raises(DownloadError):
-        await utils.download_file(context, "url", path, session=fake_session_500)
+        await utils.download_file(fake_session_500, "url", path)
 
 
 @pytest.mark.asyncio
-async def test_download_file_404(context, fake_session_404, tmpdir):
+async def test_download_file_404(fake_session_404, tmpdir):
     path = os.path.join(tmpdir, "foo")
     with pytest.raises(Download404):
-        await utils.download_file(context, "url", path, session=fake_session_404)
+        await utils.download_file(fake_session_404, "url", path)
 
 
 # format_json {{{1
@@ -395,7 +395,7 @@ async def test_load_json_or_yaml_from_url(context, mocker, overwrite, file_type,
         path
     )
     assert await utils.load_json_or_yaml_from_url(
-        context, "", path, overwrite=overwrite
+        context.session, "", path, overwrite=overwrite
     ) == {"credentials": ["blah"]}
 
 


### PR DESCRIPTION
This is a small discussion-y PR to coax out a code style discussion.
Within `scriptworker`, we have a `Context` object that, IMHO, is venturing into ["god object"](https://en.wikipedia.org/wiki/God_object) territory. This is noticeable in a couple ways:

* Tests are less isolated: almost all of them depend on the `context` fixtures. When debugging why a test is failing, the information for that test isn't all local: it's spread throughout some shared test setup that's highly generic. There's a lot of setup that's irrelevant for individual tests (e.g.: setting up a session when a test is just checking config). For example, see the changes to the `test_get_single_upstream_artifact_full_path` test in this PR to see what kind of improvements I'm imagining
* It's harder to find out where a variable is used. For example, `context.proc` (in [task.py](https://github.com/mozilla-releng/scriptworker/blob/master/scriptworker/task.py#L436)) is mostly only used in `task.py`, but since it's on the context object, it _could_ be used in `*scripts`, or perhaps accessed in a not-easily-greppable way elsewhere in `scriptworker`
* It's making it harder to call some functions: they require `context` as a parameter, but perhaps only need `context.config`. This is forcing my calling function to need to set up a _whole_ `context`, even if only a subset is needed.

I think that a good remedy to this situation is to only pass around the subset of `context` that we need. Additionally, we should peel off chunks of `context` that don't actually need to be a part of it, such as [`write_json`](https://github.com/mozilla-releng/scriptworker/blob/master/scriptworker/context.py#L163-L175)