### PR TITLE
Use `git_path` for git binary

### DIFF
--- a/scriptworker.yaml.tmpl
+++ b/scriptworker.yaml.tmpl
@@ -74,6 +74,9 @@ base_gpg_home_dir: "/tmp/gpg"
 # this lockfile prevents multiple rebuild-gpg-homedir processes from clobbering each other
 gpg_lockfile: "/tmp/gpg_homedir.lock"
 
+# the path to the git executable
+git_path: git
+
 # the git_key_repo_url is cloned into git_key_repo_dir.
 git_key_repo_dir: "/tmp/key_repo"
 

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -113,7 +113,7 @@ DEFAULT_CONFIG = frozendict({
     "base_gpg_home_dir": "...",
     "gpg_lockfile": os.path.join(os.getcwd(), "gpg_homedir.lock"),
     # The path to the git executable.
-    "git_path": None,
+    "git_path": 'git',
     "git_key_repo_dir": "...",
     "git_key_repo_url": "https://github.com/mozilla-releng/cot-gpg-keys.git",
     "last_good_git_revision_file": os.path.join(os.getcwd(), "git_revision"),

--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -112,6 +112,8 @@ DEFAULT_CONFIG = frozendict({
 
     "base_gpg_home_dir": "...",
     "gpg_lockfile": os.path.join(os.getcwd(), "gpg_homedir.lock"),
+    # The path to the git executable.
+    "git_path": None,
     "git_key_repo_dir": "...",
     "git_key_repo_url": "https://github.com/mozilla-releng/cot-gpg-keys.git",
     "last_good_git_revision_file": os.path.join(os.getcwd(), "git_revision"),

--- a/scriptworker/gpg.py
+++ b/scriptworker/gpg.py
@@ -1168,7 +1168,20 @@ def rebuild_gpg_home_signed(context, real_gpg_home, my_pub_key_path,
 
 
 # git {{{1
-async def get_git_revision(path, ref="HEAD",
+def guess_git_path(context):
+    """Guess git_path.
+
+    Args:
+        context (scriptworker.context.Context): the scriptworker context.
+
+    Returns:
+        str: either ``context.config['git_path']`` or 'git' if that's not defined.
+
+    """
+    return context.config['git_path'] or 'git'
+
+
+async def get_git_revision(context, path, ref="HEAD",
                            exec_function=asyncio.create_subprocess_exec):
     """Get the git revision of path.
 
@@ -1184,7 +1197,7 @@ async def get_git_revision(path, ref="HEAD",
 
     """
     proc = await exec_function(
-        'git', "log", "-n1", "--format=format:%H", ref, cwd=path,
+        guess_git_path(context), "log", "-n1", "--format=format:%H", ref, cwd=path,
         stdout=PIPE, stderr=DEVNULL, stdin=DEVNULL, close_fds=True,
     )
     revision, err = await proc.communicate()
@@ -1196,7 +1209,7 @@ async def get_git_revision(path, ref="HEAD",
     return revision.decode('utf-8').rstrip()
 
 
-async def get_latest_tag(path,
+async def get_latest_tag(context, path,
                          exec_function=asyncio.create_subprocess_exec):
     """Get the latest tag in path.
 
@@ -1211,7 +1224,7 @@ async def get_latest_tag(path,
 
     """
     proc = await exec_function(
-        'git', "describe", "--abbrev=0", cwd=path,
+        guess_git_path(context), "describe", "--abbrev=0", cwd=path,
         stdout=PIPE, stderr=DEVNULL, stdin=DEVNULL, close_fds=True,
     )
     tag, err = await proc.communicate()
@@ -1259,15 +1272,15 @@ async def update_signed_git_repo(context, repo="origin", ref="master",
             )
 
     for cmd in (
-        ["git", "checkout", ref],
-        ["git", "pull", "--ff-only", "--tags", repo],
+        [guess_git_path(context), "checkout", ref],
+        [guess_git_path(context), "pull", "--ff-only", "--tags", repo],
     ):
         await _run_git_cmd(cmd)
 
-    tag = await get_latest_tag(path)
-    await _run_git_cmd(["git", "checkout", tag])
+    tag = await get_latest_tag(context, path)
+    await _run_git_cmd([guess_git_path(context), "checkout", tag])
     await verify_signed_tag(context, tag)
-    revision = await get_git_revision(path, tag)
+    revision = await get_git_revision(context, path, tag)
     return revision, tag
 
 
@@ -1284,13 +1297,13 @@ async def verify_signed_tag(context, tag, exec_function=subprocess.check_call):
     """
     path = context.config['git_key_repo_dir']
     try:
-        exec_function(["git", "tag", "-v", tag], cwd=path)
+        exec_function([guess_git_path(context), "tag", "-v", tag], cwd=path)
     except subprocess.CalledProcessError as exc:
         raise ScriptWorkerGPGException(
             "Can't verify tag {} signature at {}: {}".format(tag, path, str(exc))
         )
-    tag_revision = await get_git_revision(path, tag)
-    head_revision = await get_git_revision(path, "HEAD")
+    tag_revision = await get_git_revision(context, path, tag)
+    head_revision = await get_git_revision(context, path, "HEAD")
     if tag_revision != head_revision:
         raise ScriptWorkerGPGException(
             "{}: Tag {} revision {} != current revision {}!".format(

--- a/scriptworker/gpg.py
+++ b/scriptworker/gpg.py
@@ -1184,7 +1184,7 @@ async def get_git_revision(context, path, ref="HEAD",
 
     """
     proc = await exec_function(
-        context['git_path'], "log", "-n1", "--format=format:%H", ref, cwd=path,
+        context.config['git_path'], "log", "-n1", "--format=format:%H", ref, cwd=path,
         stdout=PIPE, stderr=DEVNULL, stdin=DEVNULL, close_fds=True,
     )
     revision, err = await proc.communicate()
@@ -1211,7 +1211,7 @@ async def get_latest_tag(context, path,
 
     """
     proc = await exec_function(
-        context['git_path'], "describe", "--abbrev=0", cwd=path,
+        context.config['git_path'], "describe", "--abbrev=0", cwd=path,
         stdout=PIPE, stderr=DEVNULL, stdin=DEVNULL, close_fds=True,
     )
     tag, err = await proc.communicate()
@@ -1259,13 +1259,13 @@ async def update_signed_git_repo(context, repo="origin", ref="master",
             )
 
     for cmd in (
-        [context['git_path'], "checkout", ref],
-        [context['git_path'], "pull", "--ff-only", "--tags", repo],
+        [context.config['git_path'], "checkout", ref],
+        [context.config['git_path'], "pull", "--ff-only", "--tags", repo],
     ):
         await _run_git_cmd(cmd)
 
     tag = await get_latest_tag(context, path)
-    await _run_git_cmd([context['git_path'], "checkout", tag])
+    await _run_git_cmd([context.config['git_path'], "checkout", tag])
     await verify_signed_tag(context, tag)
     revision = await get_git_revision(context, path, tag)
     return revision, tag
@@ -1284,7 +1284,7 @@ async def verify_signed_tag(context, tag, exec_function=subprocess.check_call):
     """
     path = context.config['git_key_repo_dir']
     try:
-        exec_function([context['git_path'], "tag", "-v", tag], cwd=path)
+        exec_function([context.config['git_path'], "tag", "-v", tag], cwd=path)
     except subprocess.CalledProcessError as exc:
         raise ScriptWorkerGPGException(
             "Can't verify tag {} signature at {}: {}".format(tag, path, str(exc))

--- a/scriptworker/test/test_gpg.py
+++ b/scriptworker/test/test_gpg.py
@@ -619,26 +619,26 @@ def test_rebuild_gpg_home_signed(context, trusted_email, tmpdir):
 
 # get_git_revision, get_latest_tag {{{1
 @pytest.mark.asyncio
-async def test_get_git_revision(tmpdir):
+async def test_get_git_revision(context, tmpdir):
     tar = tarfile.open(os.path.join(os.path.dirname(__file__), "data", "test_git_repo.tgz"))
     tar.extractall(tmpdir)
     parent_dir = os.path.join(tmpdir, "testrepo")
     expected = "3e9ed77c7a6de4f8103a742e1d03ce292cf65a13"
-    assert await sgpg.get_git_revision(parent_dir) == expected
+    assert await sgpg.get_git_revision(context, parent_dir) == expected
 
 
 @pytest.mark.asyncio
-async def test_get_latest_tag(tmpdir):
+async def test_get_latest_tag(context, tmpdir):
     tar = tarfile.open(os.path.join(os.path.dirname(__file__), "data", "test_git_repo.tgz"))
     tar.extractall(tmpdir)
     parent_dir = os.path.join(tmpdir, "testrepo")
     expected = "v2"
-    assert await sgpg.get_latest_tag(parent_dir) == expected
+    assert await sgpg.get_latest_tag(context, parent_dir) == expected
 
 
 @pytest.mark.parametrize("func", (sgpg.get_git_revision, sgpg.get_latest_tag))
 @pytest.mark.asyncio
-async def test_get_git_revision_exception(mocker, func):
+async def test_get_git_revision_exception(context, mocker, func):
     x = mock.MagicMock()
 
     async def fake(*args, **kwargs):
@@ -655,7 +655,7 @@ async def test_get_git_revision_exception(mocker, func):
 
     parent_dir = os.path.dirname(__file__)
     with pytest.raises(ScriptWorkerRetryException):
-        await func(parent_dir, exec_function=fake)
+        await func(context, parent_dir, exec_function=fake)
 
 
 # update_signed_git_repo {{{1
@@ -704,7 +704,7 @@ async def test_update_signed_git_repo(context, mocker, result1, result2, expecte
 @pytest.mark.asyncio
 async def test_verify_signed_tag(context, mocker, valid_signed, head_rev, tag_rev, raises):
 
-    async def fake_revision(path, ref):
+    async def fake_revision(context, path, ref):
         if ref == "HEAD":
             return head_rev
         return tag_rev
@@ -826,3 +826,9 @@ def test_write_last_good_git_revision_exception(context, mocker):
     mocker.patch.object(sgpg, "open", new=boom)
     with pytest.raises(OSError):
         sgpg.write_last_good_git_revision(context, "foo")
+
+
+@pytest.mark.parametrize("git_path, expected", (("path/to/git", "path/to/git"), (None, "git")))
+def test_guess_git_path(base_context, git_path, expected):
+    base_context.config['git_path'] = git_path
+    assert sgpg.guess_git_path(base_context) == expected

--- a/scriptworker/test/test_gpg.py
+++ b/scriptworker/test/test_gpg.py
@@ -826,9 +826,3 @@ def test_write_last_good_git_revision_exception(context, mocker):
     mocker.patch.object(sgpg, "open", new=boom)
     with pytest.raises(OSError):
         sgpg.write_last_good_git_revision(context, "foo")
-
-
-@pytest.mark.parametrize("git_path, expected", (("path/to/git", "path/to/git"), (None, "git")))
-def test_guess_git_path(base_context, git_path, expected):
-    base_context.config['git_path'] = git_path
-    assert sgpg.guess_git_path(base_context) == expected

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (17, 2, 3)
+__version__ = (18, 0, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (17, 2, 2)
+__version__ = (17, 2, 3)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         17,
         2,
-        2
+        3
     ],
-    "version_string": "17.2.2"
+    "version_string": "17.2.3"
 }

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
-        17,
-        2,
-        3
+        18,
+        0,
+        0
     ],
-    "version_string": "17.2.3"
+    "version_string": "18.0.0"
 }


### PR DESCRIPTION
This is very similar to `gpg_path`. We will need this because the `git` binary is not in PATH in the nix generated docker images.