### PR TITLE
verify_cot --verify-sigs option

### DIFF
--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -2228,7 +2228,7 @@ async def _async_verify_cot_cmdln(opts, tmp):
             'artifact_dir': os.path.join(tmp, 'artifacts'),
             'task_log_dir': os.path.join(tmp, 'artifacts', 'public', 'logs'),
             'base_gpg_home_dir': os.path.join(tmp, 'gpg'),
-            'verify_cot_signature': False,
+            'verify_cot_signature': opts.verify_sigs,
         })
         context.config = apply_product_config(context.config)
         cot = ChainOfTrust(context, opts.task_type, task_id=opts.task_id)
@@ -2268,6 +2268,7 @@ or in the CREDS_FILES http://bit.ly/2fVMu0A""")
     parser.add_argument('--cleanup', help='clean up the temp dir afterwards',
                         dest='cleanup', action='store_true', default=False)
     parser.add_argument('--cot-product', help='the product type to test', default='firefox')
+    parser.add_argument('--verify-sigs', help='enable signature verification', action='store_true', default=False)
     opts = parser.parse_args(args)
     tmp = tempfile.mkdtemp()
     log = logging.getLogger('scriptworker')

--- a/scriptworker/test/test_integration.py
+++ b/scriptworker/test/test_integration.py
@@ -401,7 +401,7 @@ async def test_verify_production_cot(branch_context):
 
     async def verify_cot(name, task_id, task_type):
         log.info("Verifying {} {} {}...".format(name, task_id, task_type))
-        async with get_context({'verify_cot_signature': False}) as context:
+        async with get_context() as context:
             context.task = await queue.task(task_id)
             cot = ChainOfTrust(context, task_type, task_id=task_id)
             await verify_chain_of_trust(cot)


### PR DESCRIPTION
ed25519 + the known level 3 pubkeys makes this a viable thing to do locally. Currently it only works with level 3 graphs, since we don't have the level 1 pubkeys anywhere.

This will fail if we have to fall back to gpg signature verification.