### PR TITLE
Fix #326 - github-push: use committer data instead of author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [23.0.1] - 2019-04-11
+### Fixed
+- CoT on Github: PRs merged by someone else break CoT
+
 ## [23.0.0] - 2019-03-27
 ### Added
 - added `CODE_OF_CONDUCT.md`.

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1202,7 +1202,7 @@ async def _get_additional_github_push_jsone_context(decision_link):
             'ref': get_branch(task, source_env_prefix),
             'after': commit_hash,
             'sender': {
-                'login': commit_data['author']['login'],
+                'login': commit_data['committer']['login'],
             },
         },
     }

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -1356,7 +1356,7 @@ async def test_populate_jsone_context_git_cron(mobile_chain, mobile_cron_link, h
 async def test_populate_jsone_context_github_push(mocker, mobile_chain, mobile_github_push_link):
     github_repo_mock = MagicMock()
     github_repo_mock.get_commit.return_value = {
-        'author': {
+        'committer': {
             'login': 'some-user',
         },
     }

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         23,
         0,
-        0
+        1
     ],
-    "version_string": "23.0.0"
+    "version_string": "23.0.1"
 }


### PR DESCRIPTION
See https://github.com/mozilla-mobile/reference-browser/pull/716#discussion_r274446504