### PR TITLE
Send OAuth token to GitHub

### DIFF
--- a/scriptworker/github.py
+++ b/scriptworker/github.py
@@ -114,7 +114,8 @@ class GitHubRepository():
         repo = self._github_repository.html_url
 
         url = '/'.join([repo.rstrip('/'), 'branch_commits', revision])
-        html_data = await retry_request(context, url)
+        headers = {"Authorization": "token {}".format(context.config['github_oauth_token'])}
+        html_data = await retry_request(context, url, headers=headers)
         html_text = html_data.strip()
         # https://github.com/{repo_owner}/{repo_name}/branch_commits/{revision} just returns some \n
         # when the commit hasn't landed on the origin repo. Otherwise, some HTML data is returned - it

--- a/scriptworker/test/test_github.py
+++ b/scriptworker/test/test_github.py
@@ -158,7 +158,10 @@ def test_get_tag_hash(github_repository, tags, raises, expected):
 )))
 @pytest.mark.asyncio
 async def test_has_commit_landed_on_repository(context, github_repository, commitish, expected_url, html_text, raises, expected):
-    async def retry_request(_, url):
+    context.config = {'github_oauth_token': 'fakegithubtoken'}
+
+    async def retry_request(_, url, headers):
+        assert headers == {"Authorization": "token fakegithubtoken"}
         assert url == expected_url
         return html_text
 


### PR DESCRIPTION
`has_commit_landed_on_repository` doesn't go through `github3` and therefore does not enjoy the rate-limiting upgrade provided by our OAuth token.

This should fix the 429 errors seen [here](https://tools.taskcluster.net/groups/F-eFLR1YTD6dUcnYIxAg6g/tasks/SIrT2zqXSKamP5FEIOq75w/runs/0/logs/public%2Flogs%2Fchain_of_trust.log).