### PR TITLE
Bug 1547928 - enrich github releases jsone context with event action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [23.0.5] - 2019-05-13
+### Fixed
+- Fix logging
+- Enrich github releases jsone context by adding `event['action']`
+
 ## [23.0.4] - 2019-05-06
 ### Fixed
 - [Issue #334](https://github.com/mozilla-releng/scriptworker/issues/334): Github's `web-flow` user breaking Chain of Trust.

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1059,6 +1059,7 @@ async def _get_additional_github_releases_jsone_context(decision_link):
     # [2] https://developer.github.com/v3/activity/events/types/#releaseevent
     return {
         'event': {
+            'action': 'published',
             'repository': {
                 'clone_url': "{}.git".format(repo_url),
                 'full_name': extract_github_repo_full_name(repo_url),
@@ -1286,7 +1287,7 @@ async def populate_jsone_context(chain, parent_link, decision_link, tasks_for):
                 await _get_additional_github_push_jsone_context(decision_link)
             )
         else:
-            raise CoTError('Unknown tasks_for "{}" for cot_product "mobile"!'.format(tasks_for))
+            raise CoTError('Unknown tasks_for "{}" for cot_product "{}"!'.format(tasks_for, chain.context.config['cot_product']))
     else:
         jsone_context['repository']['level'] = await get_scm_level(chain.context, project)
 

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -1289,6 +1289,7 @@ async def test_populate_jsone_context_github_release(mocker, mobile_chain, mobil
     del context['as_slugid']
     assert context == {
         'event': {
+            'action': 'published',
             'repository': {
                 'clone_url': 'https://github.com/mozilla-mobile/focus-android.git',
                 'full_name': 'mozilla-mobile/focus-android',

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         23,
         0,
-        4
+        5
     ],
-    "version_string": "23.0.4"
+    "version_string": "23.0.5"
 }


### PR DESCRIPTION
After 0.51.0 was out, I landed https://github.com/mozilla-mobile/android-components/pull/2885 to prevent github releases to be triggered after editing the description or drafting it and instead, only trigger if `Publish` button was pressed. 

0.52.0 was out today and all the tasks failed CoT because `2019-05-13T15:22:38 CRITICAL - beetmover:parent Rq7PmV9jSg-DvRaact5t1w: the runtime task doesn't match any rebuilt definition!`

In order to check CoT, we rebuilt the decision task's definitions from scratch, but because the jsone context misses the `'action':'published'`, it doesn't actually render anything whilst doing the mergedeep in the `.taskcluster.yml`, resulting in an empty `rebuilt_definitions`.

```
(Pdb) pp rebuilt_definitions
{'policy': {'pullRequests': 'public'}, 'tasks': [], 'version': 1}
```

In order to fix this, we need to enrich the github release jsone context with the missing variable.

This will automatically fix fenix too for which we also deployed a similar fix - https://github.com/mozilla-mobile/fenix/pull/2317