### PR TITLE
Log workerId

### DIFF
--- a/scriptworker/task.py
+++ b/scriptworker/task.py
@@ -702,7 +702,8 @@ async def claim_work(context):
         dict: a dict containing a list of the task definitions of the tasks claimed.
 
     """
-    log.debug("Calling claimWork...")
+    log.debug("Calling claimWork for {}/{}...".format(
+        context.config['worker_group'], context.config['worker_id']))
     payload = {
         'workerGroup': context.config['worker_group'],
         'workerId': context.config['worker_id'],

--- a/scriptworker/worker.py
+++ b/scriptworker/worker.py
@@ -12,6 +12,7 @@ import logging
 import os
 import sys
 import signal
+import socket
 import typing
 
 from scriptworker.artifacts import upload_artifacts
@@ -228,6 +229,7 @@ def main(event_loop=None):
     """
     context, credentials = get_context_from_cmdln(sys.argv[1:])
     log.info("Scriptworker starting up at {} UTC".format(arrow.utcnow().format()))
+    log.info("Worker FQDN: {}".format(socket.getfqdn()))
     cleanup(context)
     context.event_loop = event_loop or asyncio.get_event_loop()
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         23,
         3,
-        1
+        2
     ],
-    "version_string": "23.3.0"
+    "version_string": "23.3.2"
 }


### PR DESCRIPTION
In GCP we use slugid to generate workerId and it's harder to connect the random k8s replica name to this workerId.