### PR TITLE
Graceful shutdown without cancelling via SIGUSR1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [XX.Y.Z] - TODO
+## [23.6.2] - 2019-07-26
+
+### Added
+- Support for graceful shutdown without cancelling using SIGUSR1
+
 ### Removed
 - Support for old `application-services-r` workerType
 

--- a/scriptworker/worker.py
+++ b/scriptworker/worker.py
@@ -242,7 +242,14 @@ def main(event_loop=None):
         if context.running_tasks is not None:
             await context.running_tasks.cancel()
 
+    async def _handle_sigusr1():
+        """Stop accepting new tasks."""
+        log.info("SIGUSR1 received; no more tasks will be taken")
+        nonlocal done
+        done = True
+
     context.event_loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.ensure_future(_handle_sigterm()))
+    context.event_loop.add_signal_handler(signal.SIGUSR1, lambda: asyncio.ensure_future(_handle_sigusr1()))
 
     while not done:
         try:

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         23,
         6,
-        1
+        2
     ],
-    "version_string": "23.6.1"
+    "version_string": "23.6.2"
 }


### PR DESCRIPTION
I hit some issues deploying autoscaling in GCP (Kubernetes). The idea was to employ the fact that [Kubernetes sends](https://kubernetes.io/docs/concepts/workloads/pods/pod/?source=post_page---------------------------#termination-of-pods) `SIGTERM` N seconds (30 by default) before killing the container to let the application clean up the state. For some reason I thought that scriptworker handles `SIGTERM`by not taking any more tasks. Apparently we also cancel the running task in order to report `machine-shutdown` and upload logs.

This patch adds another handler for `SIGUSR1` that does almost the same, but without cancelling the running task. We will use the Kubernetes' `preStop` hook to run a script which will send `SIGUSR1` to scriptworker and then watch the status  of the process. If the process doesn't exit in N seconds, the script will give up and let Kubernetes send a `SIGTERM`.

Example `preStop` script:
```bash
#!/bin/sh

# scriptworker runs as PID 1 in Kubernetes
SCRIPTWORKER_PID=${SCRIPTWORKER_PID:-1}
# See https://kubernetes.io/docs/concepts/workloads/pods/pod/?source=post_page---------------------------#termination-of-pods
# for the details
# Kubernetes executes this script synchronously and waits for it to finish. If
# the script doesn't finish in `terminationGracePeriodSeconds`, it sends
# SIGTERM, waits 2 seconds and kills the container. To prevent this scenario
# in case the task takes too long, this script exits 2 minutes before
# `terminationGracePeriodSeconds` to let scriptworker upload files and report
# `machine-shutdown` to Taskcluster.
POLL_DURATION=1080
POLL_INTERVAL=5

started=$(date +%s)

echo "Sending SIGUSR1 signal to process id $SCRIPTWORKER_PID"

kill -s USR1 $SCRIPTWORKER_PID

while true; do
    echo "checking status..."
    kill -0 $SCRIPTWORKER_PID
    status=$?

    if [ $status -eq 0 ]; then
        echo "Process finished, exiting"
        exit 0
    fi

    now=$(date +%s)
    duration=$[ $now - $started ]

    if [ $duration -gt $POLL_DURATION ]; then
        echo "Waited too long ($duration), giving up"
        exit 1
    fi

    echo "Sleeping for $POLL_INTERVAL"
    sleep $POLL_INTERVAL
done
```

This way we try our best to let scriptworker to finish the existing tasks without actively checking their state (idleness).