### PR TITLE
Use `verify_scriptworker_task` explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [24.0.2] - 2019-08-12
+### Changed
+- Use `verify_scriptworker_task` for workers indirectly using it
+
 ## [24.0.1] - 2019-08-08
 ### Added
 - Added new scriptworker names to CoT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [24.0.2] - 2019-08-12
+## [25.0.0] - 2019-08-12
+### Removed
+- Removed the following stub functions:
+  - verify_balrog_task
+  - verify_bouncer_task
+  - verify_pushapk_task
+  - verify_pushsnap_task
+  - verify_shipit_task
+  - verify_signing_task
 ### Changed
 - Use `verify_scriptworker_task` for workers indirectly using it
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 aiohttp
-arrow
+arrow<=0.14.4
 cryptography>=2.6.1
 dictdiffer
 frozendict

--- a/scriptworker.yaml.tmpl
+++ b/scriptworker.yaml.tmpl
@@ -43,7 +43,7 @@ sign_chain_of_trust: false
 verify_chain_of_trust: false
 verify_cot_signature: false
 # Chain of Trust job type, e.g. signing
-cot_job_type: signing
+cot_job_type: scriptworker
 cot_product: firefox
 # Calls to Github API are limited to 60 an hour. Using an API token allows to raise the limit to
 # 5000 per hour. https://developer.github.com/v3/#rate-limiting

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -424,19 +424,19 @@ def get_valid_task_types():
     """
     return frozendict({
         'scriptworker': verify_scriptworker_task,
-        'balrog': verify_balrog_task,
-        'beetmover': verify_beetmover_task,
-        'bouncer': verify_bouncer_task,
+        'balrog': verify_scriptworker_task,
+        'beetmover': verify_scriptworker_task,
+        'bouncer': verify_scriptworker_task,
         'build': verify_build_task,
         'l10n': verify_build_task,
         'repackage': verify_build_task,
         'action': verify_parent_task,
         'decision': verify_parent_task,
         'docker-image': verify_docker_image_task,
-        'pushapk': verify_pushapk_task,
-        'pushsnap': verify_pushsnap_task,
-        'shipit': verify_shipit_task,
-        'signing': verify_signing_task,
+        'pushapk': verify_scriptworker_task,
+        'pushsnap': verify_scriptworker_task,
+        'shipit': verify_scriptworker_task,
+        'signing': verify_scriptworker_task,
         'partials': verify_partials_task,
     })
 
@@ -1719,23 +1719,6 @@ async def verify_docker_image_task(chain, link):
     raise_on_errors(errors)
 
 
-# verify_balrog_task {{{1
-async def verify_balrog_task(chain, obj):
-    """Verify the balrog trust object.
-
-    Currently the only check is to make sure it was run on a scriptworker.
-
-    Args:
-        chain (ChainOfTrust): the chain we're operating on
-        obj (ChainOfTrust or LinkOfTrust): the trust object for the balrog task.
-
-    Raises:
-        CoTError: on error.
-
-    """
-    return await verify_scriptworker_task(chain, obj)
-
-
 # verify_partials_task {{{1
 async def verify_partials_task(chain, obj):
     """Verify the partials trust object.
@@ -1752,105 +1735,6 @@ async def verify_partials_task(chain, obj):
 
     """
     pass
-
-
-# verify_beetmover_task {{{1
-async def verify_beetmover_task(chain, obj):
-    """Verify the beetmover trust object.
-
-    Currently the only check is to make sure it was run on a scriptworker.
-
-    Args:
-        chain (ChainOfTrust): the chain we're operating on
-        obj (ChainOfTrust or LinkOfTrust): the trust object for the beetmover task.
-
-    Raises:
-        CoTError: on error.
-
-    """
-    return await verify_scriptworker_task(chain, obj)
-
-
-async def verify_bouncer_task(chain, obj):
-    """Verify the bouncer trust object.
-
-    Currently the only check is to make sure it was run on a scriptworker.
-
-    Args:
-        chain (ChainOfTrust): the chain we're operating on
-        obj (ChainOfTrust or LinkOfTrust): the trust object for the beetmover task.
-
-    Raises:
-        CoTError: on error.
-
-    """
-    return await verify_scriptworker_task(chain, obj)
-
-
-# verify_pushapk_task {{{1
-async def verify_pushapk_task(chain, obj):
-    """Verify the pushapk trust object.
-
-    Currently the only check is to make sure it was run on a scriptworker.
-
-    Args:
-        chain (ChainOfTrust): the chain we're operating on
-        obj (ChainOfTrust or LinkOfTrust): the trust object for the pushapk task.
-
-    Raises:
-        CoTError: on error.
-
-    """
-    return await verify_scriptworker_task(chain, obj)
-
-
-async def verify_pushsnap_task(chain, obj):
-    """Verify the pushsnap trust object.
-
-    Currently the only check is to make sure it was run on a scriptworker.
-
-    Args:
-        chain (ChainOfTrust): the chain we're operating on
-        obj (ChainOfTrust or LinkOfTrust): the trust object for the pushsnap task.
-
-    Raises:
-        CoTError: on error.
-
-    """
-    return await verify_scriptworker_task(chain, obj)
-
-
-async def verify_shipit_task(chain, obj):
-    """Verify the ship-it trust object.
-
-    Currently the only check is to make sure it was run on a scriptworker.
-
-    Args:
-        chain (ChainOfTrust): the chain we're operating on
-        obj (ChainOfTrust or LinkOfTrust): the trust object for the ship-it task.
-
-    Raises:
-        CoTError: on error.
-
-    """
-    return await verify_scriptworker_task(chain, obj)
-
-
-# verify_signing_task {{{1
-async def verify_signing_task(chain, obj):
-    """Verify the signing trust object.
-
-    Currently the only check is to make sure it was run on a scriptworker.
-
-    Args:
-        chain (ChainOfTrust): the chain we're operating on
-        obj (ChainOfTrust or LinkOfTrust): the trust object for the signing task.
-
-    Raises:
-        CoTError: on error.
-
-    """
-    return await verify_scriptworker_task(chain, obj)
 
 
 # check_num_tasks {{{1

--- a/scriptworker/test/__init__.py
+++ b/scriptworker/test/__init__.py
@@ -275,7 +275,7 @@ def _craft_rw_context(tmp, event_loop, cot_product, session):
     context = Context()
     context.session = session
     context.config = apply_product_config(config)
-    context.config['cot_job_type'] = "signing"
+    context.config['cot_job_type'] = "scriptworker"
     for key, value in context.config.items():
         if key.endswith("_dir"):
             context.config[key] = os.path.join(tmp, key)

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -2173,20 +2173,14 @@ async def test_verify_docker_image_task_worker_type(chain, docker_image_link):
 
 
 # verify_scriptworker_task {{{1
-@pytest.mark.parametrize("func", ["verify_balrog_task", "verify_beetmover_task",
-                                  "verify_bouncer_task", "verify_pushapk_task",
-                                  "verify_pushsnap_task", "verify_shipit_task",
-                                  "verify_signing_task", "verify_partials_task",
-                                  "verify_scriptworker_task"])
+@pytest.mark.parametrize("func", ["verify_partials_task", "verify_scriptworker_task"])
 @pytest.mark.asyncio
 async def test_verify_scriptworker_task(chain, build_link, func):
     build_link.worker_impl = 'scriptworker'
     await getattr(cotverify, func)(chain, build_link)
 
 
-@pytest.mark.parametrize("func", ["verify_balrog_task", "verify_beetmover_task",
-                                  "verify_pushapk_task", "verify_signing_task",
-                                  "verify_scriptworker_task"])
+@pytest.mark.parametrize("func", ["verify_scriptworker_task"])
 @pytest.mark.asyncio
 async def test_verify_scriptworker_task_worker_impl(chain, build_link, func):
     build_link.worker_impl = 'bad_impl'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if {'register', 'upload'}.intersection(set(sys.argv)):
 
 reqs = [
     "aiohttp>=3",
-    "arrow",
+    "arrow<=0.14.4",
     "cryptography>=2.6.1",
     "dictdiffer",
     "frozendict",

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         24,
         0,
-        1
+        2
     ],
-    "version_string": "24.0.1"
+    "version_string": "24.0.2"
 }

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
-        24,
+        25,
         0,
-        2
+        0
     ],
-    "version_string": "24.0.2"
+    "version_string": "25.0.0"
 }


### PR DESCRIPTION
The new treescript workers use `cot_job_type` set to `tree` instead of
generic `scriptworker` we use in puppet. This require a new entry in
`get_valid_task_types`.