### PR TITLE
run_task returns 1 on non-zero exit code, 0 on success.

### DIFF
--- a/scriptworker/task.py
+++ b/scriptworker/task.py
@@ -584,7 +584,7 @@ async def run_task(context, to_cancellable_process):
         to_cancellable_process (types.Callable): tracks the process so that it can be stopped if the worker is shut down
 
     Returns:
-        int: exit code
+        int: 1 on failure, 0 on success
 
     """
     env = deepcopy(os.environ)
@@ -637,7 +637,7 @@ async def run_task(context, to_cancellable_process):
     if stopped_due_to_worker_shutdown:
         raise WorkerShutdownDuringTask
 
-    return exitcode
+    return 1 if exitcode != 0 else 0
 
 
 # reclaim_task {{{1


### PR DESCRIPTION
Fixes https://github.com/mozilla-releng/signingscript/issues/128 .

Note: We may want to allow scripts to exit one of the known status
codes. If so, we should amend this to check if the exit code is in
scriptworker.constants.STATUSES.values(), and return 1 if it's not.