### PR TITLE
Github push: Expose repo name and pusher's email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [26.0.1] - 2019-08-26
+### Fixed
+- run_task returns 1 on non-zero exit code, 0 on success.
+- Chain of Trust breakage: Expose repo name and pusher's email on github pushes.
+
 ## [26.0.0] - 2019-08-16
 ### Added
 - Support taskgraph-style github cron contexts.

--- a/scriptworker/test/test_cot_verify.py
+++ b/scriptworker/test/test_cot_verify.py
@@ -1428,14 +1428,22 @@ async def test_populate_jsone_context_git_cron(mobile_chain, mobile_cron_link, h
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize('committer_login, author_login', (
-    ('some-user', 'some-user'),
-    ('some-user', 'some-other-user'),
-    ('web-flow', 'some-user'),
+@pytest.mark.parametrize('committer_login, committer_email, author_login, author_email', (
+    ('some-user', 'some-user@email.tld', 'some-user', 'some-user@email.tld'),
+    ('some-user', 'some-user@email.tld', 'some-other-user', 'other@email.tld'),
+    ('web-flow', 'noreply@github.com', 'some-user', 'some-user@email.tld'),
 ))
-async def test_populate_jsone_context_github_push(mocker, mobile_chain, mobile_github_push_link, committer_login, author_login):
+async def test_populate_jsone_context_github_push(mocker, mobile_chain, mobile_github_push_link, committer_login, committer_email, author_login, author_email):
     github_repo_mock = MagicMock()
     github_repo_mock.get_commit.return_value = {
+        'commit': {
+            'author': {
+                'email': author_email,
+            },
+            'committer': {
+                'email': committer_email,
+            },
+        },
         'committer': {
             'login': committer_login,
         },
@@ -1454,13 +1462,17 @@ async def test_populate_jsone_context_github_push(mocker, mobile_chain, mobile_g
     del context['as_slugid']
     assert context == {
         'event': {
+            'after': 'somerevision',
+            'pusher': {
+                'email': 'some-user@email.tld',
+            },
+            'ref': 'refs/heads/some-branch',
             'repository': {
                 'full_name': 'mozilla-mobile/focus-android',
                 'html_url': 'https://github.com/mozilla-mobile/focus-android',
+                'name': 'focus-android',
                 'pushed_at': '1549022400',
             },
-            'ref': 'refs/heads/some-branch',
-            'after': 'somerevision',
             'sender': {
                 'login': 'some-user',
             },

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (26, 0, 0)
+__version__ = (26, 0, 1)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version":[
         26,
         0,
-        0
+        1
     ],
-    "version_string":"26.0.0"
+    "version_string":"26.0.1"
 }


### PR DESCRIPTION
Fixes https://taskcluster-artifacts.net/ILSInA2nRFyOd3zOGI8tOg/0/public/logs/chain_of_trust.log: 

```
scriptworker.exceptions.CoTError: CoTError('JSON-e error while rebuilding signing:parent task definition: TemplateError at template.tasks[0]: pusher not found in {"repository": {"full_name": "mozilla-mobile/reference-browser", "html_url": "https://github.com/mozilla-mobile/reference-browser", "pushed_at": null}, "ref": "refs/heads/master", "after": "1875923349a126b224a7e5970ed096723cb37e94", "sender": {"login": "pocmo"}}',)
```

It was introduced in https://github.com/mozilla-mobile/reference-browser/pull/737/files#diff-ac0229d1171c0983b27003af4c7441a5R19. 

cc @pocmo 