### PR TITLE
Mobile: Fix staging crons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [26.0.2] - 2019-08-30
+### Fixed
+- Chain of Trust breakage: Staging cron context were bailing out because repos were unknown.
+
 ## [26.0.1] - 2019-08-26
 ### Fixed
 - run_task returns 1 on non-zero exit code, 0 on success.

--- a/scriptworker/cot/verify.py
+++ b/scriptworker/cot/verify.py
@@ -1116,7 +1116,7 @@ async def _get_additional_git_cron_jsone_context(decision_link):
     source_env_prefix = decision_link.context.config['source_env_prefix']
     task = decision_link.task
     repo = get_repo(task, source_env_prefix)
-    project = await get_project(decision_link.context, repo)
+    _, repo_name = extract_github_repo_owner_and_name(repo)
     revision = get_revision(task, source_env_prefix)
     branch = get_branch(task, source_env_prefix)
 
@@ -1153,8 +1153,8 @@ async def _get_additional_git_cron_jsone_context(decision_link):
         # Taskgraph cron contexts mirror hg-push contexts
         'repository': {
             'url': repo,
-            'project': project,
-            'level': await get_scm_level(decision_link.context, project)
+            'project': repo_name,
+            'level': await get_scm_level(decision_link.context, repo_name)
         },
         'push': {
             'revision': revision,

--- a/scriptworker/version.py
+++ b/scriptworker/version.py
@@ -52,7 +52,7 @@ def get_version_string(version):
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (26, 0, 1)
+__version__ = (26, 0, 2)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version":[
         26,
         0,
-        1
+        2
     ],
-    "version_string":"26.0.1"
+    "version_string":"26.0.2"
 }


### PR DESCRIPTION
Regressed in #368. @ColinTheShots came across that error[1]: 

```
scriptworker.exceptions.CoTError: CoTError('Error while rebuilding signing:parent M-3BfvqQQsKov7kas24NoQ task definition!\nUnknown repo for source url https://github.com/colintheshots/fenix!',)
```

@mitchhentges told me he got the same one recently too.

@tomprince said staging releases shouldn't look up known projects anymore[2]. I realized `cron` contexts was still fetching that. This patch fixes this.

It was tested with:

```
verify_cot --cleanup --task-type signing --cot-product mobile 'f3EN1BJUTtWIEj8jurxXFA'
```

[1] https://tools.taskcluster.net/groups/M-3BfvqQQsKov7kas24NoQ/tasks/f3EN1BJUTtWIEj8jurxXFA/runs/0/logs/public%2Flogs%2Fchain_of_trust.log#L126
[2] https://github.com/mozilla-releng/scriptworker/pull/368#pullrequestreview-264213896