### PR TITLE
Update fenix CoT restrictions, adds all release channels

### DIFF
--- a/scriptworker/constants.py
+++ b/scriptworker/constants.py
@@ -324,7 +324,9 @@ DEFAULT_CONFIG = frozendict({
                 'project:mobile:android-components:releng:beetmover:bucket:maven-snapshot-production': 'android-components-repo',
 
                 'project:mobile:fenix:releng:googleplay:product:fenix': 'fenix-repo',
-                'project:mobile:fenix:releng:signing:cert:release-signing': 'fenix-repo',
+                'project:mobile:fenix:releng:signing:cert:nightly-signing': 'fenix-repo',
+                'project:mobile:fenix:releng:signing:cert:beta-signing': 'fenix-repo',
+                'project:mobile:fenix:releng:signing:cert:production-signing': 'fenix-repo',
 
                 'project:mobile:focus:googleplay:product:focus': 'focus-repo',
                 'project:mobile:focus:releng:signing:cert:release-signing': 'focus-repo',


### PR DESCRIPTION
All three channels of `nightly`, `beta` and `production` should only be sign-able on level 3.
Also note that `release-signing` scope was replaced by `production-signing`, as visible by [this task](https://tools.taskcluster.net/groups/LiA4OwpkTJymka1zFZVc_g/tasks/K0-GhxY4T2WWTCzAG_n_Og/details)