### PR TITLE
`arrow.get` no longer takes timestamp strings without a format string

### DIFF
--- a/scriptworker/utils.py
+++ b/scriptworker/utils.py
@@ -115,7 +115,7 @@ def datestring_to_timestamp(datestring):
         int: the corresponding timestamp.
 
     """
-    return arrow.get(datestring).timestamp
+    return arrow.get(float(datestring)).timestamp
 
 
 # to_unicode {{{1


### PR DESCRIPTION
Fixes #394 .