### PR TITLE
Bug 1613800 - part 2: add old docker-worker cot key back

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[33.0.2] - 2020-04-01 (genuinely not an April Fools' joke)
+----------------------------------------------------------
+
+Added
+~~~~~
+- Old docker-worker cot key which was removed in 33.0.0, because it broke mobile releases.
+
 [33.0.1] - 2020-03-30
 ---------------------
 

--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -80,7 +80,9 @@ DEFAULT_CONFIG = immutabledict(
         "ed25519_private_key_path": "...",
         "ed25519_public_keys": immutabledict(
             {
-                "docker-worker": tuple(["tk/SjxY3mREARba6ODw7qReUoVWj0RgEIxBURkwcM4I="]),
+                # the key beginning in J+PAK... is the longstanding docker-worker CoT key, to be phased out
+                # the key beginning in tk/Sj... is a new key added to differentiate GCP workers
+                "docker-worker": tuple(["J+PAKmq3jkS2uCpBk5WU2ycrnTFPwZujJT4OHAxm38I=", "tk/SjxY3mREARba6ODw7qReUoVWj0RgEIxBURkwcM4I="]),
                 "generic-worker": tuple(["6UPrVTyw0EPQV7bCEMXo+5jNR4clbK55JWG74bBJHZQ="]),
                 "scriptworker": tuple(["DaEKQ79ZC/X+7O8zwm8iyhwTlgyjRSi/TDd63fh2JG0="]),
             }

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (33, 0, 1)
+__version__ = (33, 0, 2)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version":[
         33,
         0,
-        1
+        2
     ],
-    "version_string":"33.0.1"
+    "version_string":"33.0.2"
 }


### PR DESCRIPTION
This reverts https://github.com/mozilla-releng/scriptworker/pull/447. It broke mobile releases:

```
2020-04-01T09:34:52    DEBUG -     Verifying the scriptworker:build:docker-image aP4nedQnTAWQl2fKawVGwg docker-worker ed25519 chain of trust signature
2020-04-01T09:34:52 CRITICAL - Chain of Trust verification error!
Traceback (most recent call last):
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 1905, in verify_chain_of_trust
    verify_cot_signatures(chain)
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 836, in verify_cot_signatures
    verify_link_ed25519_cot_signature(chain, link, unsigned_path, ed25519_signature_path)
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 815, in verify_link_ed25519_cot_signature
    raise CoTError(message)
scriptworker.exceptions.CoTError: '"scriptworker:build:docker-image aP4nedQnTAWQl2fKawVGwg: docker-worker ed25519 cot signature doesn\'t verify against tk/SjxY3mREARba6ODw7qReUoVWj0RgEIxBURkwcM4I=: "'
```

https://firefox-ci-tc.services.mozilla.com/tasks/BBN7xM39Tzi4EZXojWXj5A/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FBBN7xM39Tzi4EZXojWXj5A%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Fchain_of_trust.log#L54

Full task group: https://firefox-ci-tc.services.mozilla.com/tasks/groups/LeSantlsRcKDxmUhGC9o9w

I guess there's a better solution, like maybe rebuilding old docker images. That said, I found some new gecko workers were created (for instance https://firefox-ci-tc.services.mozilla.com/provisioners/gecko-3/worker-types/b-linux-gcp), but mobile ones don't have them (yet?) https://firefox-ci-tc.services.mozilla.com/provisioners/mobile-3.

This issue is blocking the Fennec to Fenix beta migration which is currently ongoing. Thus, I prefer to re-enable this key and deprecate it later. @escapewindow, please let me know if you need more context 🙂