### PR TITLE
Bug 1618731 - retry getting task definition

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,14 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[33.1.0] - 2020-04-07
+---------------------
+
+Added
+~~~~~
+- ``retry_get_task_definition`` and ``get_task_definition`` to fix `Bug 1618731
+   <https://bugzilla.mozilla.org/show_bug.cgi?id=1618731>`__
+
 [33.0.2] - 2020-04-01 (genuinely not an April Fools' joke)
 ----------------------------------------------------------
 

--- a/src/scriptworker/task.py
+++ b/src/scriptworker/task.py
@@ -81,6 +81,7 @@ async def retry_get_task_definition(queue, task_id, exception=TaskclusterFailure
             Defaults to ``TaskclusterFailure``.
 
     """
+    kwargs.setdefault("retry_exceptions", tuple(set([TaskclusterFailure, exception])))
     return await retry_async(get_task_definition, args=(queue, task_id), kwargs={"exception": exception}, **kwargs)
 
 

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (33, 0, 2)
+__version__ = (33, 1, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/tests/test_cot_verify.py
+++ b/tests/test_cot_verify.py
@@ -2061,8 +2061,6 @@ def test_verify_cot_cmdln(chain, args, tmpdir, mocker, event_loop, use_github_to
     if use_github_token:
         monkeypatch.setenv("SCRIPTWORKER_GITHUB_OAUTH_TOKEN", "sometoken")
     context = MagicMock()
-    context.queue = MagicMock()
-    context.queue.task = noop_async
     path = os.path.join(tmpdir, "x")
     makedirs(path)
 
@@ -2084,6 +2082,7 @@ def test_verify_cot_cmdln(chain, args, tmpdir, mocker, event_loop, use_github_to
     mocker.patch.object(cotverify, "read_worker_creds", new=noop_sync)
     mocker.patch.object(cotverify, "Context", new=get_context)
     mocker.patch.object(cotverify, "ChainOfTrust", new=cot)
+    mocker.patch.object(cotverify, "retry_get_task_definition", new=noop_async)
     mocker.patch.object(cotverify, "verify_chain_of_trust", new=noop_async)
 
     cotverify.verify_cot_cmdln(args=args, event_loop=event_loop)

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
         33,
-        0,
-        2
+        1,
+        0
     ],
-    "version_string":"33.0.2"
+    "version_string":"33.1.0"
 }


### PR DESCRIPTION
This also detects if the task definition we receive is an empty `{}` (currently just by checking the existence of `payload`). In theory that should be a taskcluster error.