### PR TITLE
check generic-worker interactive tasks. raise on docker-worker interactive tasks.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,20 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[34.0.0] - 2020-04-17
+---------------------
+
+Added
+~~~~~
+- added ``check_interactive_generic_worker``
+
+Changed
+~~~~~~~
+- ``check_interactive_docker_worker`` now raises ``CoTError`` on errors, rather
+    than returning the list of error messages
+- ``check_interactive_docker_worker`` now also runs against the chain task, if it's
+    docker-worker
+
 [33.1.1] - 2020-04-09
 ---------------------
 

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -456,7 +456,7 @@ def check_interactive_generic_worker(link):
     """Given a task, make sure the task was not defined as interactive.
 
     * ``task.payload.rdpInfo`` must be absent or False.
-    * ``task.payload.env.TASKCLUSTER_INTERACTIVE`` must be absent or False.
+    * ``task.payload.scopes`` must not contain a scope starting with ``generic-worker:allow-rdp:``
 
     Args:
         link (LinkOfTrust): the task link we're checking.

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (33, 1, 1)
+__version__ = (34, 0, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
-        33,
-        1,
-        1
+        34,
+        0,
+        0
     ],
-    "version_string":"33.1.1"
+    "version_string":"34.0.0"
 }


### PR DESCRIPTION
The generic-worker rdp info is [here](https://github.com/taskcluster/taskcluster/blob/05c5897fafc9d96f5c7f8f8e9dd0ecb08831c358/workers/generic-worker/schemas/multiuser_windows.yml#L296-L325).

This patch:
1. changes `verify_docker_worker_task` to run `check_interactive_docker_worker`, even if the target task is the `chain` task (i.e., the specific task we want to verify the chain against). Since `check_interactive_docker_worker` doesn't check `link.cot`, we don't require that task to have finished yet.
2. raises `CoTError` on an interactive docker-worker task. Previously we returned a list of errors, which we then ignored. I'm not thrilled with this, but we're partially protected by ci-admin checks and the fact that the interactive flag would need to be set in-tree to affect a release graph.
3. adds a `check_interactive_generic_worker`, which we call in `verify_generic_worker_task`.

@JohanLorenzo @tomprince what do you think?