### PR TITLE
bug 1594621 - add cot_product_type map

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,24 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[34.1.0] - 2020-05-04
+---------------------
+
+Added
+~~~~~
+- added ``cot_product_type``
+
+Changed
+~~~~~~~
+- ``populate_jsone_context`` now checks ``cot_product_type`` instead of allowlisting a set of ``cot_products`` as github
+
+Changed
+~~~~~~~
+- ``check_interactive_docker_worker`` now raises ``CoTError`` on errors, rather
+    than returning the list of error messages
+- ``check_interactive_docker_worker`` now also runs against the chain task, if it's
+    docker-worker
+
 [34.0.0] - 2020-04-17
 ---------------------
 

--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -111,6 +111,22 @@ DEFAULT_CONFIG = immutabledict(
         "scriptworker_provisioners": ("scriptworker-prov-v1", "scriptworker-k8s"),
         # valid hash algorithms for chain of trust artifacts
         "valid_hash_algorithms": ("sha256", "sha512"),
+        "cot_product_type": immutabledict(
+            {
+                "by-cot-product": immutabledict(
+                    {
+                        "firefox": "hg",
+                        "thunderbird": "hg",
+                        "mobile": "github",
+                        "mpd001": "github",
+                        "application-services": "github",
+                        "xpi": "github",
+                        "adhoc": "github",
+                        "scriptworker": "github",
+                    },
+                ),
+            },
+        ),
         # decision task cot
         "valid_decision_worker_pools": immutabledict(
             {

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -1239,7 +1239,8 @@ async def populate_jsone_context(chain, parent_link, decision_link, tasks_for):
         "taskId": None,
     }
 
-    if chain.context.config["cot_product"] in ("mobile", "mpd001", "application-services", "xpi"):
+    # XXX add cot_product_type: by-cot-product: COT_PRODUCT: (github|hgmo) ?
+    if chain.context.config["cot_product"] in ("mobile", "mpd001", "application-services", "xpi", "adhoc"):
         if tasks_for == "github-release":
             jsone_context.update(await _get_additional_github_releases_jsone_context(decision_link))
         elif tasks_for == "cron":

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -1239,8 +1239,7 @@ async def populate_jsone_context(chain, parent_link, decision_link, tasks_for):
         "taskId": None,
     }
 
-    # XXX add cot_product_type: by-cot-product: COT_PRODUCT: (github|hgmo) ?
-    if chain.context.config["cot_product"] in ("mobile", "mpd001", "application-services", "xpi", "adhoc"):
+    if chain.context.config["cot_product_type"] == "github":
         if tasks_for == "github-release":
             jsone_context.update(await _get_additional_github_releases_jsone_context(decision_link))
         elif tasks_for == "cron":
@@ -1252,8 +1251,8 @@ async def populate_jsone_context(chain, parent_link, decision_link, tasks_for):
         elif tasks_for == "github-push":
             jsone_context.update(await _get_additional_github_push_jsone_context(decision_link))
         else:
-            raise CoTError('Unknown tasks_for "{}" for cot_product "{}"!'.format(tasks_for, chain.context.config["cot_product"]))
-    else:
+            raise CoTError('Unknown tasks_for "{}" for github cot_product "{}"!'.format(tasks_for, chain.context.config["cot_product"]))
+    elif chain.context.config["cot_product_type"] == "hg":
         source_url = get_source_url(decision_link)
         project = await get_project(chain.context, source_url)
         jsone_context["repository"] = {
@@ -1269,7 +1268,11 @@ async def populate_jsone_context(chain, parent_link, decision_link, tasks_for):
         elif tasks_for == "cron":
             jsone_context.update(await _get_additional_hg_cron_jsone_context(parent_link, decision_link))
         else:
-            raise CoTError("Unknown tasks_for {}!".format(tasks_for))
+            raise CoTError('Unknown tasks_for "{}" for hg cot_product "{}"!'.format(tasks_for, chain.context.config["cot_product"]))
+    else:
+        raise CoTError(
+            'Unknown cot_product_type "{}" for cot_product "{}"!'.format(chain.context.config["cot_product_type"], chain.context.config["cot_product"])
+        )
 
     log.debug("{} json-e context:".format(parent_link.name))
     # format_json() breaks on lambda values; use pprint.pformat here.

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (34, 0, 0)
+__version__ = (34, 1, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/tests/test_cot_verify.py
+++ b/tests/test_cot_verify.py
@@ -1270,6 +1270,9 @@ async def test_populate_jsone_context_github_pull_request(mocker, mobile_chain_p
 async def test_populate_jsone_context_fail(mobile_chain, mobile_github_release_link):
     with pytest.raises(CoTError):
         await cotverify.populate_jsone_context(mobile_chain, mobile_github_release_link, mobile_github_release_link, tasks_for="bad-tasks-for")
+    mobile_chain.context.config["cot_product_type"] = "bad-cot-product-type"
+    with pytest.raises(CoTError):
+        await cotverify.populate_jsone_context(mobile_chain, mobile_github_release_link, mobile_github_release_link, tasks_for="github-push")
 
 
 @pytest.mark.asyncio

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
         34,
-        0,
+        1,
         0
     ],
-    "version_string":"34.0.0"
+    "version_string":"34.1.0"
 }


### PR DESCRIPTION
In [this adhoc task](https://firefox-ci-tc.services.mozilla.com/tasks/HNPN1sluQ8mTmLNaG3KB0w), we got a bad `tasks_for` error, because we have a large `if` statement that whitelists a bunch of `cot_product`s.

Let's create a `cot_product_type` map that we can check, so we don't have to update this `if` block every time we add a new github product.