### PR TITLE
fix xpi private cot verification

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,18 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[34.2.0] - 2020-05-26
+---------------------
+
+Changed
+~~~~~~~
+- Github source urls starting with ``ssh://`` are now treated as private repositories.
+- ``verify_cot`` now takes ``--verbose`` and ``--no-check-task`` options.
+
+Fixed
+~~~~~
+- ``test_production`` should no longer leave behind temp ``...`` directories.
+
 [34.1.0] - 2020-05-04
 ---------------------
 

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (34, 1, 0)
+__version__ = (34, 2, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -34,9 +34,10 @@ def build_config(override, basedir):
     config.update(
         {
             "log_dir": os.path.join(basedir, "log"),
-            "base_artifact_dir": os.path.join(basedir, "artifact"),
-            "task_log_dir_template": os.path.join(basedir, "artifact", "public", "logs"),
-            "base_work_dir": os.path.join(basedir, "work"),
+            "artifact_dir": os.path.join(basedir, "artifact"),
+            "task_log_dir": os.path.join(basedir, "artifact", "public", "logs"),
+            "work_dir": os.path.join(basedir, "work"),
+            "ed25519_private_key_path": "",
         }
     )
     del config["credentials"]
@@ -45,6 +46,10 @@ def build_config(override, basedir):
     with open(os.path.join(basedir, "config.json"), "w") as fh:
         json.dump(config, fh, indent=2, sort_keys=True)
     config = apply_product_config(config)
+    # Avoid creating a `...` directory
+    for k,v in config.items():
+        if v == '...':
+            raise Exception(f"Let's not keep any '...' config values. {k} is {v}!")
     return config
 
 

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -47,8 +47,8 @@ def build_config(override, basedir):
         json.dump(config, fh, indent=2, sort_keys=True)
     config = apply_product_config(config)
     # Avoid creating a `...` directory
-    for k,v in config.items():
-        if v == '...':
+    for k, v in config.items():
+        if v == "...":
             raise Exception(f"Let's not keep any '...' config values. {k} is {v}!")
     return config
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
         34,
-        1,
+        2,
         0
     ],
-    "version_string":"34.1.0"
+    "version_string":"34.2.0"
 }


### PR DESCRIPTION
Previously, we assumed that we would list any and all private github repos in `constants.py`. However, with the xpi project, we'll get many private repos that we will want to verify without needing to land a change in scriptworker.

Let's allow for `ssh://github.com` source urls to imply a private repository.

As ridealongs, I added `--verbose` and `--no-check-task` to `verify-cot`. I also cleaned up some extraneous output at the end of `verify_cot`.

Also, the second patch gets us to stop creating `...` directories while running `test_production.py` tests.

The `base_*_dir` and `task_log_dir_template` config entries were from a historic, unmerged PR. Let's set the actual config paths inside our tempdir. Bonus: we won't have weird bustage related to hardcoded directory paths if and when we run two concurrent sets of tests.

I tested this patchset against the tasks in https://firefox-ci-tc.services.mozilla.com/tasks/groups/NFYpj38mQdSJGRxqG44_Iw , after setting `SCRIPTWORKER_GITHUB_OAUTH_TOKEN` to a token with read access to the private repo. I can invite you to my `test-xpi-private` repo if you want to give it a spin.

@Callek , @JohanLorenzo do you have cycles to look at this?