### PR TITLE
Bug 1563169 - enable CoT github-push on app-services and glean.

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -290,13 +290,18 @@ DEFAULT_CONFIG = immutabledict(
                     "mpd001": ("cron", "github-pull-request", "github-push", "github-release"),
                     # TODO: Once 1563169 is resolved, this CoT product will be removed
                     "application-services": (
+                        "action",
+                        "cron",
                         # On staging releases, level 1 docker images may be built in the pull-request graph
                         "github-pull-request",
                         # Similarly, docker images can be built on regular push. This is usually the case
                         # for level 3 images
+                        "github-push",
                         "github-release",
                     ),
                     "app-services": (
+                        "action",
+                        "cron",
                         # On staging releases, level 1 docker images may be built in the pull-request graph
                         "github-pull-request",
                         # Similarly, docker images can be built on regular push. This is usually the case
@@ -305,6 +310,8 @@ DEFAULT_CONFIG = immutabledict(
                         "github-release",
                     ),
                     "glean": (
+                        "action",
+                        "cron",
                         # On staging releases, level 1 docker images may be built in the pull-request graph
                         "github-pull-request",
                         # Similarly, docker images can be built on regular push. This is usually the case


### PR DESCRIPTION
We allow `github-push` for level-3 image building. 