### PR TITLE
Bug 1664167 - add `before` context in jsone_push context

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,17 +4,29 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[35.3.0] - 2020-09-10
+---------------------
+
+Fixed
+~~~~~
+- CoT now supports Github ``event.before`` in the jsone context.
+
+Changed
+~~~~~~~
+- Reformatted to fix black and isort
+
 [35.2.0] - 2020-06-19
+---------------------
 
 Added
-~~~~~~~~
+~~~~~
 - Added support for `esr78` for both `comm` and `gecko`
 
 [35.1.0] - 2020-06-10
 ---------------------
 
 Added
-~~~~~~~
+~~~~~
 - Added `build_taskcluster_yml_url`
 
 Changed

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,7 @@ with open(PATH) as filehandle:
 
 
 class Tox(TestCommand):
-    """http://bit.ly/1T0dwvG
-    """
+    """http://bit.ly/1T0dwvG"""
 
     user_options = [("tox-args=", "a", "Arguments to pass to tox")]
 
@@ -71,8 +70,9 @@ class Tox(TestCommand):
 
     def run_tests(self):
         # import here, cause outside the eggs aren't loaded
-        import tox
         import shlex
+
+        import tox
 
         args = self.tox_args
         if args:

--- a/src/scriptworker/artifacts.py
+++ b/src/scriptworker/artifacts.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import aiohttp
 import arrow
 import async_timeout
+
 from scriptworker.client import validate_artifact_url
 from scriptworker.exceptions import DownloadError, ScriptWorkerRetryException, ScriptWorkerTaskException
 from scriptworker.task import get_decision_task_id, get_run_id, get_task_id

--- a/src/scriptworker/client.py
+++ b/src/scriptworker/client.py
@@ -19,6 +19,7 @@ from urllib.parse import unquote
 
 import aiohttp
 import jsonschema
+
 from scriptworker.constants import STATUSES
 from scriptworker.context import Context
 from scriptworker.exceptions import ScriptWorkerException, ScriptWorkerTaskException, TaskVerificationError

--- a/src/scriptworker/config.py
+++ b/src/scriptworker/config.py
@@ -16,12 +16,13 @@ from collections import Mapping
 from copy import deepcopy
 
 from immutabledict import immutabledict
+from yaml import safe_load
+
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context
 from scriptworker.exceptions import ConfigError
 from scriptworker.log import update_logging_config
 from scriptworker.utils import load_json_or_yaml
-from yaml import safe_load
 
 log = logging.getLogger(__name__)
 

--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -133,17 +133,40 @@ DEFAULT_CONFIG = immutabledict(
             {
                 "by-cot-product": immutabledict(
                     {
-                        "firefox": ("gecko-1/decision", "gecko-2/decision", "gecko-3/decision",),
-                        "thunderbird": ("comm-1/decision", "comm-2/decision", "comm-3/decision",),
-                        "mobile": ("mobile-1/decision", "mobile-3/decision",),
+                        "firefox": (
+                            "gecko-1/decision",
+                            "gecko-2/decision",
+                            "gecko-3/decision",
+                        ),
+                        "thunderbird": (
+                            "comm-1/decision",
+                            "comm-2/decision",
+                            "comm-3/decision",
+                        ),
+                        "mobile": (
+                            "mobile-1/decision",
+                            "mobile-3/decision",
+                        ),
                         "mpd001": ("mpd001-1/decision", "mpd001-3/decision"),
                         # TODO: Once 1563169 is resolved, this CoT product will be removed
-                        "application-services": ("app-services-1/decision", "app-services-3/decision",),
-                        "app-services": ("app-services-1/decision", "app-services-3/decision",),
-                        "glean": ("glean-1/decision", "glean-3/decision",),
+                        "application-services": (
+                            "app-services-1/decision",
+                            "app-services-3/decision",
+                        ),
+                        "app-services": (
+                            "app-services-1/decision",
+                            "app-services-3/decision",
+                        ),
+                        "glean": (
+                            "glean-1/decision",
+                            "glean-3/decision",
+                        ),
                         "xpi": ("xpi-1/decision", "xpi-3/decision"),
                         "adhoc": ("adhoc-1/decision", "adhoc-3/decision"),
-                        "scriptworker": ("scriptworker-1/decision", "scriptworker-3/decision",),
+                        "scriptworker": (
+                            "scriptworker-1/decision",
+                            "scriptworker-3/decision",
+                        ),
                     }
                 )
             }
@@ -153,17 +176,40 @@ DEFAULT_CONFIG = immutabledict(
             {
                 "by-cot-product": immutabledict(
                     {
-                        "firefox": ("gecko-1/images", "gecko-2/images", "gecko-3/images",),
-                        "thunderbird": ("comm-1/images", "comm-2/images", "comm-3/images",),
-                        "mobile": ("mobile-1/images", "mobile-3/images",),
+                        "firefox": (
+                            "gecko-1/images",
+                            "gecko-2/images",
+                            "gecko-3/images",
+                        ),
+                        "thunderbird": (
+                            "comm-1/images",
+                            "comm-2/images",
+                            "comm-3/images",
+                        ),
+                        "mobile": (
+                            "mobile-1/images",
+                            "mobile-3/images",
+                        ),
                         "mpd001": ("mpd001-1/images", "mpd001-3/images"),
                         # TODO: Once 1563169 is resolved, this CoT product will be removed
-                        "application-services": ("app-services-1/images", "app-services-3/images",),
-                        "app-services": ("app-services-1/images", "app-services-3/images",),
-                        "glean": ("glean-1/images", "glean-3/images",),
+                        "application-services": (
+                            "app-services-1/images",
+                            "app-services-3/images",
+                        ),
+                        "app-services": (
+                            "app-services-1/images",
+                            "app-services-3/images",
+                        ),
+                        "glean": (
+                            "glean-1/images",
+                            "glean-3/images",
+                        ),
                         "xpi": ("xpi-1/images", "xpi-3/images"),
                         "adhoc": ("adhoc-1/images", "adhoc-3/images"),
-                        "scriptworker": ("scriptworker-1/images", "scriptworker-3/images",),
+                        "scriptworker": (
+                            "scriptworker-1/images",
+                            "scriptworker-3/images",
+                        ),
                     }
                 )
             }
@@ -452,7 +498,10 @@ DEFAULT_CONFIG = immutabledict(
                             "release": ("/releases/mozilla-release",),
                             "beta": ("/releases/mozilla-beta",),
                             "beta-or-release": ("/releases/mozilla-beta", "/releases/mozilla-release"),
-                            "esr": ("/releases/mozilla-esr68", "/releases/mozilla-esr78",),
+                            "esr": (
+                                "/releases/mozilla-esr68",
+                                "/releases/mozilla-esr78",
+                            ),
                             "esr68": ("/releases/mozilla-esr68",),
                             "nightly": ("/mozilla-central",),
                             # Which repos can do nightly signing?
@@ -480,10 +529,22 @@ DEFAULT_CONFIG = immutabledict(
                     ),
                     "thunderbird": immutabledict(
                         {
-                            "all-release-branches": ("/releases/comm-beta", "/releases/comm-esr68", "/releases/comm-esr78",),
+                            "all-release-branches": (
+                                "/releases/comm-beta",
+                                "/releases/comm-esr68",
+                                "/releases/comm-esr78",
+                            ),
                             "beta": ("/releases/comm-beta",),
-                            "esr": ("/releases/comm-esr68", "/releases/comm-esr78",),
-                            "all-nightly-branches": ("/comm-central", "/releases/comm-beta", "/releases/comm-esr68", "/releases/comm-esr78",),
+                            "esr": (
+                                "/releases/comm-esr68",
+                                "/releases/comm-esr78",
+                            ),
+                            "all-nightly-branches": (
+                                "/comm-central",
+                                "/releases/comm-beta",
+                                "/releases/comm-esr68",
+                                "/releases/comm-esr78",
+                            ),
                             "nightly": ("/comm-central",),
                         }
                     ),
@@ -507,7 +568,10 @@ DEFAULT_CONFIG = immutabledict(
                     "scriptworker": immutabledict(
                         {
                             "scriptworker-scripts-repo": ("/mozilla-releng/scriptworker-scripts",),
-                            "all-production-repos": ("/mozilla-releng/scriptworker", "/mozilla-releng/scriptworker-scripts",),
+                            "all-production-repos": (
+                                "/mozilla-releng/scriptworker",
+                                "/mozilla-releng/scriptworker-scripts",
+                            ),
                         }
                     ),
                 }

--- a/src/scriptworker/context.py
+++ b/src/scriptworker/context.py
@@ -18,9 +18,10 @@ from copy import deepcopy
 
 import aiohttp
 import arrow
+from taskcluster.aio import Queue
+
 from scriptworker.exceptions import CoTError
 from scriptworker.utils import load_json_or_yaml_from_url, makedirs
-from taskcluster.aio import Queue
 
 log = logging.getLogger(__name__)
 

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -1167,8 +1167,8 @@ async def _get_additional_github_push_jsone_context(decision_link):
 
     # This value could have been taken from `commit_data.parents[0]` too but
     # it is more visible if picked up from `.taskcluster.yml` env vars
-    base_prefix = "{}_BASE_REV".format(context.config['source_env_prefix'])
-    before_hash = task['payload']['env'][base_prefix]
+    base_prefix = "{}_BASE_REV".format(context.config["source_env_prefix"])
+    before_hash = task["payload"]["env"][base_prefix]
 
     # Github users can have multiple emails. The commit_data contains
     # their primary email, but the task may contain a secondary email.

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -20,6 +20,8 @@ import aiohttp
 import dictdiffer
 import jsone
 from immutabledict import immutabledict
+from taskcluster.aio import Queue
+
 from scriptworker.artifacts import download_artifacts, get_artifact_url, get_optional_artifacts_per_task_id, get_single_upstream_artifact_full_path
 from scriptworker.config import apply_product_config, read_worker_creds
 from scriptworker.constants import DEFAULT_CONFIG
@@ -67,7 +69,6 @@ from scriptworker.utils import (
     write_to_file,
 )
 from scriptworker.version import __version_string__
-from taskcluster.aio import Queue
 
 log = logging.getLogger(__name__)
 

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -1165,6 +1165,11 @@ async def _get_additional_github_push_jsone_context(decision_link):
     if committer_login == "web-flow":
         committer_login = commit_data["author"]["login"]
 
+    # This value could have been taken from `commit_data.parents[0]` too but
+    # it is more visible if picked up from `.taskcluster.yml` env vars
+    base_prefix = "{}_BASE_REV".format(context.config['source_env_prefix'])
+    before_hash = task['payload']['env'][base_prefix]
+
     # Github users can have multiple emails. The commit_data contains
     # their primary email, but the task may contain a secondary email.
     # We may want to verify that this email is one of `login`'s email
@@ -1176,8 +1181,10 @@ async def _get_additional_github_push_jsone_context(decision_link):
     #
     # [1] https://developer.github.com/v3/repos/commits/#get-a-single-commit
     # [2] https://developer.github.com/v3/activity/events/types/#pushevent
+
     return {
         "event": {
+            "before": before_hash,
             "after": commit_hash,
             "pusher": {"email": task_email},
             "ref": get_branch(task, source_env_prefix),

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -1168,7 +1168,7 @@ async def _get_additional_github_push_jsone_context(decision_link):
     # This value could have been taken from `commit_data.parents[0]` too but
     # it is more visible if picked up from `.taskcluster.yml` env vars
     base_prefix = "{}_BASE_REV".format(context.config["source_env_prefix"])
-    before_hash = task["payload"]["env"][base_prefix]
+    before_hash = task["payload"]["env"].get(base_prefix)
 
     # Github users can have multiple emails. The commit_data contains
     # their primary email, but the task may contain a secondary email.

--- a/src/scriptworker/ed25519.py
+++ b/src/scriptworker/ed25519.py
@@ -15,6 +15,7 @@ from binascii import Error as Base64Error
 from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.exceptions import ScriptWorkerEd25519Error, ScriptWorkerException
 from scriptworker.utils import read_from_file

--- a/src/scriptworker/github.py
+++ b/src/scriptworker/github.py
@@ -6,6 +6,7 @@ import re
 from aiomemoizettl import memoize_ttl
 from github3 import GitHub
 from github3.exceptions import GitHubException
+
 from scriptworker.exceptions import ConfigError
 from scriptworker.utils import get_parts_of_url_path, get_single_item_from_sequence, retry_async_decorator, retry_request, retry_sync
 

--- a/src/scriptworker/task.py
+++ b/src/scriptworker/task.py
@@ -18,6 +18,8 @@ from copy import deepcopy
 import aiohttp
 import taskcluster
 import taskcluster.exceptions
+from taskcluster.exceptions import TaskclusterFailure
+
 from scriptworker.constants import get_reversed_statuses
 from scriptworker.exceptions import ScriptWorkerTaskException, WorkerShutdownDuringTask
 from scriptworker.github import (
@@ -30,7 +32,6 @@ from scriptworker.github import (
 from scriptworker.log import get_log_filehandle, pipe_to_log
 from scriptworker.task_process import TaskProcess
 from scriptworker.utils import get_parts_of_url_path, retry_async
-from taskcluster.exceptions import TaskclusterFailure
 
 log = logging.getLogger(__name__)
 

--- a/src/scriptworker/utils.py
+++ b/src/scriptworker/utils.py
@@ -23,8 +23,9 @@ import aiohttp
 import arrow
 import async_timeout
 import yaml
-from scriptworker.exceptions import Download404, DownloadError, ScriptWorkerException, ScriptWorkerRetryException, ScriptWorkerTaskException
 from taskcluster.client import createTemporaryCredentials
+
+from scriptworker.exceptions import Download404, DownloadError, ScriptWorkerException, ScriptWorkerRetryException, ScriptWorkerTaskException
 
 log = logging.getLogger(__name__)
 

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (35, 2, 0)
+__version__ = (35, 3, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/src/scriptworker/worker.py
+++ b/src/scriptworker/worker.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import aiohttp
 import arrow
+
 from scriptworker.artifacts import upload_artifacts
 from scriptworker.config import get_context_from_cmdln
 from scriptworker.constants import STATUSES

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,14 +32,13 @@ AT_LEAST_PY38 = sys.version_info >= (3, 8)
 
 
 def read(path):
-    """Return the contents of a file.
-    """
+    """Return the contents of a file."""
     with open(path, "r", encoding="utf-8") as fh:
         return fh.read()
 
 
 def touch(path):
-    """ Create an empty file.  Different from the system 'touch' in that it
+    """Create an empty file.  Different from the system 'touch' in that it
     will overwrite an existing file.
     """
     with open(path, "w") as fh:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import tempfile
 import aiohttp
 import pytest
 import taskcluster.exceptions
+
 from scriptworker.config import apply_product_config, get_unfrozen_copy
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context
@@ -126,9 +127,7 @@ def tmpdir2():
 
 
 async def _close_session(obj):
-    """Get rid of all the unclosed session warnings.
-
-    """
+    """Get rid of all the unclosed session warnings."""
     if not hasattr(obj, "session"):
         return
     if isinstance(obj.session, aiohttp.ClientSession):

--- a/tests/data/cotv4/decision_github_private.json
+++ b/tests/data/cotv4/decision_github_private.json
@@ -18,6 +18,7 @@
   ],
   "payload": {
     "env": {
+      "MPD001_BASE_REV": "330ea928b42ff2403fc99cd3e596d13294fe8775",
       "MPD001_BASE_REPOSITORY": "git@github.com:mozilla-services/guardian-vpn.git",
       "MPD001_HEAD_REPOSITORY": "git@github.com:mozilla-services/guardian-vpn.git",
       "MPD001_HEAD_REF": "refs/heads/releng-release",

--- a/tests/data/cotv4/decision_github_private.json
+++ b/tests/data/cotv4/decision_github_private.json
@@ -18,7 +18,6 @@
   ],
   "payload": {
     "env": {
-      "MPD001_BASE_REV": "330ea928b42ff2403fc99cd3e596d13294fe8775",
       "MPD001_BASE_REPOSITORY": "git@github.com:mozilla-services/guardian-vpn.git",
       "MPD001_HEAD_REPOSITORY": "git@github.com:mozilla-services/guardian-vpn.git",
       "MPD001_HEAD_REF": "refs/heads/releng-release",

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -8,6 +8,7 @@ import tempfile
 import arrow
 import mock
 import pytest
+
 import scriptworker.artifacts as swartifacts
 from scriptworker.artifacts import (
     _craft_artifact_put_headers,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 import aiohttp
 import arrow
 import pytest
+
 import scriptworker.client as client
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,8 +8,9 @@ from copy import deepcopy
 
 import mock
 import pytest
-import scriptworker.config as config
 from immutabledict import immutabledict
+
+import scriptworker.config as config
 from scriptworker.constants import DEFAULT_CONFIG
 
 # constants helpers and fixtures {{{1

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -9,8 +9,9 @@ from copy import deepcopy
 
 import mock
 import pytest
-import scriptworker.context as swcontext
 import taskcluster
+
+import scriptworker.context as swcontext
 from scriptworker.exceptions import CoTError
 
 

--- a/tests/test_cot_generate.py
+++ b/tests/test_cot_generate.py
@@ -6,6 +6,7 @@ import logging
 import os
 
 import pytest
+
 import scriptworker.cot.generate as cot
 from scriptworker.exceptions import ScriptWorkerException
 

--- a/tests/test_cot_verify.py
+++ b/tests/test_cot_verify.py
@@ -211,6 +211,7 @@ def mobile_github_push_link(mobile_chain):
         mobile_chain, tasks_for="github-push", source_url="https://github.com/mozilla-mobile/focus-android/raw/somerevision/.taskcluster.yml"
     )
     decision_link.task["payload"]["env"] = {
+        "MOBILE_BASE_REV": "somebaserevision",
         "MOBILE_HEAD_BRANCH": "refs/heads/some-branch",
         "MOBILE_HEAD_REPOSITORY": "https://github.com/mozilla-mobile/focus-android",
         "MOBILE_HEAD_REV": "somerevision",
@@ -1162,6 +1163,7 @@ async def test_populate_jsone_context_github_push(mocker, mobile_chain, mobile_g
     del context["as_slugid"]
     assert context == {
         "event": {
+            "before": "somebaserevision",
             "after": "somerevision",
             "pusher": {"email": "foo@example.tld"},
             "ref": "refs/heads/some-branch",

--- a/tests/test_cot_verify.py
+++ b/tests/test_cot_verify.py
@@ -12,9 +12,10 @@ from unittest.mock import MagicMock
 import aiohttp
 import jsone
 import pytest
+from immutabledict import immutabledict
+
 import scriptworker.context as swcontext
 import scriptworker.cot.verify as cotverify
-from immutabledict import immutabledict
 from scriptworker.artifacts import get_single_upstream_artifact_full_path
 from scriptworker.exceptions import CoTError, DownloadError
 from scriptworker.utils import load_json_or_yaml, makedirs, read_from_file

--- a/tests/test_ed25519.py
+++ b/tests/test_ed25519.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 import scriptworker.ed25519 as swed25519
 from scriptworker.exceptions import ScriptWorkerEd25519Error
 from scriptworker.utils import read_from_file

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from scriptworker import github
 from scriptworker.exceptions import ConfigError
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,12 +11,13 @@ import tempfile
 import aiohttp
 import arrow
 import pytest
+import slugid
+from asyncio_extras.contextmanager import async_contextmanager
+
 import scriptworker.artifacts as artifacts
 import scriptworker.log as swlog
 import scriptworker.utils as utils
 import scriptworker.worker as worker
-import slugid
-from asyncio_extras.contextmanager import async_contextmanager
 from scriptworker.config import CREDS_FILES, apply_product_config, get_unfrozen_copy, read_worker_creds
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context
@@ -155,8 +156,7 @@ async def task_status(context, task_id):
 
 @async_contextmanager
 async def remember_cwd():
-    """http://stackoverflow.com/a/170174
-    """
+    """http://stackoverflow.com/a/170174"""
     curdir = os.getcwd()
     try:
         yield

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -8,6 +8,7 @@ import os
 from asyncio.subprocess import PIPE
 
 import pytest
+
 import scriptworker.log as swlog
 
 from . import read

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -10,14 +10,15 @@ import tempfile
 
 import aiohttp
 import pytest
+from asyncio_extras.contextmanager import async_contextmanager
+from taskcluster.aio import Index, Queue, Secrets
+
 import scriptworker.log as swlog
 import scriptworker.utils as utils
-from asyncio_extras.contextmanager import async_contextmanager
 from scriptworker.config import apply_product_config, get_unfrozen_copy, read_worker_creds
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context
 from scriptworker.cot.verify import ChainOfTrust, verify_chain_of_trust
-from taskcluster.aio import Index, Queue, Secrets
 
 log = logging.getLogger(__name__)
 
@@ -222,11 +223,16 @@ async def test_verify_production_cot(branch_context):
         assert task_id, "{}: Can't get task_id from index {}!".format(branch_context["name"], branch_context["index"])
         if branch_context.get("task_label_to_task_type"):
             task_info = await get_completed_task_info_from_labels(task_id, branch_context["task_label_to_task_type"])
-            assert "check_task" not in branch_context, "{}: Can't disable check_task.".format(branch_context["name"],)
+            assert "check_task" not in branch_context, "{}: Can't disable check_task.".format(
+                branch_context["name"],
+            )
             for task_id, task_type in task_info.items():
                 name = "{} {}".format(branch_context["name"], task_type)
                 await verify_cot(name, task_id, task_type)
         else:
             await verify_cot(
-                branch_context["name"], task_id, branch_context["task_type"], branch_context.get("check_task", True),
+                branch_context["name"],
+                task_id,
+                branch_context["task_type"],
+                branch_context.get("check_task", True),
             )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -13,12 +13,13 @@ from unittest.mock import MagicMock
 import arrow
 import mock
 import pytest
+import taskcluster.exceptions
+from taskcluster.exceptions import TaskclusterFailure
+
 import scriptworker.log as log
 import scriptworker.task as swtask
-import taskcluster.exceptions
 from scriptworker.exceptions import ScriptWorkerTaskException, WorkerShutdownDuringTask
 from scriptworker.task_process import TaskProcess
-from taskcluster.exceptions import TaskclusterFailure
 
 from . import TIMEOUT_SCRIPT, noop_async, read
 

--- a/tests/test_task_process.py
+++ b/tests/test_task_process.py
@@ -3,6 +3,7 @@ import signal
 
 import pytest
 from mock import MagicMock, call
+
 from scriptworker.task_process import TaskProcess
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ import time
 
 import mock
 import pytest
+
 import scriptworker.utils as utils
 from scriptworker.exceptions import Download404, DownloadError, ScriptWorkerException, ScriptWorkerRetryException
 
@@ -40,8 +41,7 @@ retry_count = {}
 
 @pytest.fixture(scope="function")
 def datestring():
-    """Datestring constant.
-    """
+    """Datestring constant."""
     return "2016-04-16T03:46:24.958Z"
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 
 import pytest
+
 import scriptworker.version as swversion
 
 # constants helpers and fixtures {{{1
@@ -27,28 +28,24 @@ def fake_version_string():
 # tests {{{1
 @pytest.mark.parametrize("version_tuple", LEGAL_VERSIONS)
 def test_legal_version(version_tuple):
-    """test_version | version tuple -> version string
-    """
+    """test_version | version tuple -> version string"""
     assert swversion.get_version_string(version_tuple[1]) == version_tuple[0]
 
 
 def test_illegal_three_version():
-    """test_version | Raise if a 3-len tuple has a non-digit
-    """
+    """test_version | Raise if a 3-len tuple has a non-digit"""
     with pytest.raises(TypeError):
         swversion.get_version_string(("one", "two", "three"))
 
 
 def test_four_version():
-    """test_version | 3 digit + string tuple -> version string
-    """
+    """test_version | 3 digit + string tuple -> version string"""
     assert swversion.get_version_string((0, 1, 0, "alpha")) == "0.1.0alpha"
 
 
 @pytest.mark.parametrize("version_tuple", ILLEGAL_LENGTH_VERSIONS)
 def test_illegal_len_version(version_tuple):
-    """test_version | Raise if len(version) not in (3, 4)
-    """
+    """test_version | Raise if len(version) not in (3, 4)"""
     with pytest.raises(Exception):
         swversion.get_version_string(version_tuple)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14,6 +14,7 @@ import aiohttp
 import arrow
 import mock
 import pytest
+
 import scriptworker.worker as worker
 from scriptworker.constants import STATUSES
 from scriptworker.exceptions import ScriptWorkerException, WorkerShutdownDuringTask
@@ -176,9 +177,7 @@ async def test_mocker_run_tasks_noop(context, successful_queue, mocker):
 
 
 def _mocker_run_tasks_helper(mocker, exc, func_to_raise):
-    """Mock run_tasks for the test_mocker_run_tasks_* tests.
-
-    """
+    """Mock run_tasks for the test_mocker_run_tasks_* tests."""
     task = {"foo": "bar", "credentials": {"a": "b"}, "task": {"task_defn": True}}
 
     async def claim_work(*args, **kwargs):
@@ -215,9 +214,7 @@ def _mocker_run_tasks_helper(mocker, exc, func_to_raise):
 )
 @pytest.mark.asyncio
 async def test_mocker_run_tasks_caught_exception(context, successful_queue, mocker, func_to_raise, exc, expected):
-    """Raise an exception within the run_tasks try/excepts and return status.
-
-    """
+    """Raise an exception within the run_tasks try/excepts and return status."""
     _mocker_run_tasks_helper(mocker, exc, func_to_raise)
 
     context.queue = successful_queue
@@ -227,9 +224,7 @@ async def test_mocker_run_tasks_caught_exception(context, successful_queue, mock
 
 @pytest.mark.asyncio
 async def test_mocker_upload_artifacts_uncaught_exception(context, successful_queue, mocker):
-    """Raise an uncaught exception within the run_tasks try/excepts.
-
-    """
+    """Raise an uncaught exception within the run_tasks try/excepts."""
     _mocker_run_tasks_helper(mocker, OSError, "upload_artifacts")
 
     context.queue = successful_queue

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
         35,
-        2,
+        3,
         0
     ],
-    "version_string":"35.2.0"
+    "version_string":"35.3.0"
 }


### PR DESCRIPTION
For Pul-requests, it reads the `event.pull_request.base.sha` which in CoT is rebuilt from github3's PyPI package's https://github3.readthedocs.io/en/master/api-reference/repos.html?highlight=repository#github3.repos.repo.ShortRepository.pull_request that returns [this type of object](https://github3.readthedocs.io/en/master/api-reference/pulls.html#github3.pulls.PullRequest)  which in turn behaves like [this](https://github3.readthedocs.io/en/master/api-reference/pulls.html#github3.pulls.ShortPullRequest) and has the [sha](https://github3.readthedocs.io/en/master/api-reference/pulls.html#github3.pulls.PullFile.sha) key. Since the github3 python package maps on Github and we use that in CoT, we naturally solve this problem in Pull-requests just by relying on the Github API, indirectly. 

So we only need to fix this for github-pushes, by adding that in the context.