### PR TITLE
Semaphore

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,9 +7,23 @@ This project adheres to `Semantic Versioning <http://semver.org/>`__.
 [X.Y.Z] - TBD
 -------------
 
-Removed
+[36.0.0] - 2020-11-20
+---------------------
+
+Added
 ~~~~~
-- CoT support for `application-services` as cleanup effort
+- Added ``semaphore_wrapper`` to easily use a semaphore for async coroutines.
+- Added ``context.download_semaphore`` to share a download semaphore.
+- Added ``max_concurrent_downloads`` pref, defaulting to 5.
+
+Fixed
+~~~~~
+- Fixed 4-part versions.
+
+Removed
+~~~~~~~
+- CoT support for ``application-services`` as cleanup effort
+- Removed ``aiohttp_max_connections`` in favor of ``max_concurrent_downloads``.
 
 [35.3.0] - 2020-09-10
 ---------------------

--- a/src/scriptworker/artifacts.py
+++ b/src/scriptworker/artifacts.py
@@ -284,6 +284,7 @@ async def download_artifacts(context, file_urls, parent_dir=None, session=None, 
                         args=(context, file_url, abs_file_path),
                         retry_exceptions=(DownloadError, aiohttp.ClientError, asyncio.TimeoutError),
                         kwargs={"session": session},
+                        sleeptime_kwargs={"max_delay": 15},
                         log_exceptions=True,
                     ),
                 )

--- a/src/scriptworker/artifacts.py
+++ b/src/scriptworker/artifacts.py
@@ -18,7 +18,7 @@ import async_timeout
 from scriptworker.client import validate_artifact_url
 from scriptworker.exceptions import DownloadError, ScriptWorkerRetryException, ScriptWorkerTaskException
 from scriptworker.task import get_decision_task_id, get_run_id, get_task_id
-from scriptworker.utils import add_enumerable_item_to_dict, download_file, get_loggable_url, raise_future_exceptions, retry_async
+from scriptworker.utils import add_enumerable_item_to_dict, download_file, get_loggable_url, raise_future_exceptions, retry_async, semaphore_wrapper
 
 log = logging.getLogger(__name__)
 
@@ -277,12 +277,15 @@ async def download_artifacts(context, file_urls, parent_dir=None, session=None, 
         files.append(abs_file_path)
         tasks.append(
             asyncio.ensure_future(
-                retry_async(
-                    download_func,
-                    args=(context, file_url, abs_file_path),
-                    retry_exceptions=(DownloadError, aiohttp.ClientError, asyncio.TimeoutError),
-                    kwargs={"session": session},
-                    log_exceptions=True,
+                semaphore_wrapper(
+                    context.download_semaphore,
+                    retry_async(
+                        download_func,
+                        args=(context, file_url, abs_file_path),
+                        retry_exceptions=(DownloadError, aiohttp.ClientError, asyncio.TimeoutError),
+                        kwargs={"session": session},
+                        log_exceptions=True,
+                    ),
                 )
             )
         )

--- a/src/scriptworker/artifacts.py
+++ b/src/scriptworker/artifacts.py
@@ -282,6 +282,7 @@ async def download_artifacts(context, file_urls, parent_dir=None, session=None, 
                     args=(context, file_url, abs_file_path),
                     retry_exceptions=(DownloadError, aiohttp.ClientError, asyncio.TimeoutError),
                     kwargs={"session": session},
+                    log_exceptions=True,
                 )
             )
         )

--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -63,7 +63,7 @@ DEFAULT_CONFIG = immutabledict(
         "artifact_dir": "...",
         "task_log_dir": "...",  # set this to ARTIFACT_DIR/public/logs
         "artifact_upload_timeout": 60 * 20,
-        "aiohttp_max_connections": 15,
+        "max_concurrent_downloads": 5,
         # chain of trust settings
         "sign_chain_of_trust": True,
         "verify_chain_of_trust": False,  # TODO True

--- a/src/scriptworker/utils.py
+++ b/src/scriptworker/utils.py
@@ -228,6 +228,7 @@ async def retry_async(
     args: Sequence[Any] = (),
     kwargs: Optional[Dict[str, Any]] = None,
     sleeptime_kwargs: Optional[Dict[str, Any]] = None,
+    log_exceptions: Optional[bool] = False,
 ) -> Any:
     """Retry ``func``, where ``func`` is an awaitable.
 
@@ -258,7 +259,9 @@ async def retry_async(
     while True:
         try:
             return await func(*args, **kwargs)
-        except retry_exceptions:
+        except retry_exceptions as exc:
+            if log_exceptions:
+                log.info(f"retry_async exception:\n{type(exc)} {exc}")
             attempt += 1
             _check_number_of_attempts(attempt, attempts, func, "retry_async")
             await asyncio.sleep(_define_sleep_time(sleeptime_kwargs, sleeptime_callback, attempt, func, "retry_async"))

--- a/src/scriptworker/utils.py
+++ b/src/scriptworker/utils.py
@@ -261,7 +261,7 @@ async def retry_async(
             return await func(*args, **kwargs)
         except retry_exceptions as exc:
             if log_exceptions:
-                log.info(f"retry_async exception:\n{type(exc)} {exc}")
+                log.warning(f"retry_async exception:\n{type(exc)} {exc}")
             attempt += 1
             _check_number_of_attempts(attempt, attempts, func, "retry_async")
             await asyncio.sleep(_define_sleep_time(sleeptime_kwargs, sleeptime_callback, attempt, func, "retry_async"))

--- a/src/scriptworker/utils.py
+++ b/src/scriptworker/utils.py
@@ -884,3 +884,28 @@ def get_single_item_from_sequence(
     if append_sequence_to_error_message:
         error_message = "{}. Given: {}".format(error_message, sequence)
     raise ErrorClass(error_message)
+
+
+# semaphore_wrapper {{{1
+async def semaphore_wrapper(semaphore, coro):
+    """Wrap an async function with semaphores.
+
+    Usage::
+
+        semaphore = asyncio.Semaphore(10)  # max 10 concurrent
+        futures = []
+        futures.append(asyncio.ensure_future(semaphore_wrapper(
+            semaphore, do_something(arg1, arg2, kwarg1='foo')
+        )))
+        await raise_future_exceptions(futures)
+
+    Args:
+        semaphore (asyncio.Semaphore): the semaphore to wrap the action with
+        coro (coroutine): an asyncio coroutine
+
+    Returns:
+        the result of ``action``.
+
+    """
+    async with semaphore:
+        return await coro

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -46,7 +46,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
     if version_len == 3:
         version_string = "%d.%d.%d" % cast(ShortVerType, version)
     elif version_len == 4:
-        version_string = "%d.%d.%d%s" % cast(LongVerType, version)
+        version_string = "%d.%d.%d.%s" % cast(LongVerType, version)
     else:
         raise Exception("Version tuple is non-semver-compliant {} length!".format(version_len))
     return version_string

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (35, 3, 0)
+__version__ = (36, 0, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/src/scriptworker/worker.py
+++ b/src/scriptworker/worker.py
@@ -210,8 +210,7 @@ async def async_main(context, credentials):
     Args:
         context (scriptworker.context.Context): the scriptworker context.
     """
-    conn = aiohttp.TCPConnector(limit=context.config["aiohttp_max_connections"])
-    async with aiohttp.ClientSession(connector=conn) as session:
+    async with aiohttp.ClientSession() as session:
         context.session = session
         context.credentials = credentials
         await run_tasks(context)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -149,3 +149,12 @@ def test_bad_verify_task(claim_task, bad_path):
     context.task = {"payload": {"upstreamArtifacts": [{"taskId": "bar", "paths": ["baz", bad_path]}]}}
     with pytest.raises(CoTError):
         context.verify_task()
+
+
+@pytest.mark.asyncio
+async def test_download_semaphore():
+    context = swcontext.Context()
+    sem = context.download_semaphore
+    assert type(sem) == asyncio.BoundedSemaphore
+    assert sem._value == swcontext.DEFAULT_MAX_CONCURRENT_DOWNLOADS
+    assert sem is context.download_semaphore

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,7 +11,7 @@ import pytest
 import scriptworker.version as swversion
 
 # constants helpers and fixtures {{{1
-LEGAL_VERSIONS = (("0.1.0", (0, 1, 0)), ("1.2.3", (1, 2, 3)), ("4.1.5", (4, 1, 5)), ("9.2.0alpha", (9, 2, 0, "alpha")))
+LEGAL_VERSIONS = (("0.1.0", (0, 1, 0)), ("1.2.3", (1, 2, 3)), ("4.1.5", (4, 1, 5)), ("9.2.0.alpha", (9, 2, 0, "alpha")))
 ILLEGAL_LENGTH_VERSIONS = ((0,), (0, 1), (0, 1, 0, "alpha", "beta"))
 
 
@@ -40,7 +40,7 @@ def test_illegal_three_version():
 
 def test_four_version():
     """test_version | 3 digit + string tuple -> version string"""
-    assert swversion.get_version_string((0, 1, 0, "alpha")) == "0.1.0alpha"
+    assert swversion.get_version_string((0, 1, 2, "alpha")) == "0.1.2.alpha"
 
 
 @pytest.mark.parametrize("version_tuple", ILLEGAL_LENGTH_VERSIONS)

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
-        35,
-        3,
+        36,
+        0,
         0
     ],
-    "version_string":"35.3.0"
+    "version_string":"36.0.0"
 }


### PR DESCRIPTION
These are changes to make the chemspill fixes more permanent.
I'm not 100% sure the aiohttp max connections were working as designed. We use semaphores elsewhere (e.g. scriptworker-scripts) and they work very well.