### PR TITLE
allow for unknown `committer_login`.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,14 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[36.0.2] - 2021-01-15
+---------------------
+
+Fixed
+~~~~~
+- Allowed for empty ``committer`` and ``author`` in github ``commit_data``
+
+
 [36.0.1] - 2020-12-14
 ---------------------
 

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -1169,10 +1169,7 @@ async def _get_additional_github_push_jsone_context(decision_link):
     #   get hung up on this.
     if committer_login in ("web-flow", None):
         author = commit_data.get("author") or {}
-        committer_login = author.get(
-            "login",
-            commit_data.get("commit", {}).get("author", {}).get("login", "@@@unknown@@@")
-        )
+        committer_login = author.get("login", commit_data.get("commit", {}).get("author", {}).get("login", "@@@unknown@@@"))
     # This value could have been taken from `commit_data.parents[0]` too but
     # it is more visible if picked up from `.taskcluster.yml` env vars
     base_prefix = "{}_BASE_REV".format(context.config["source_env_prefix"])

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -1157,7 +1157,7 @@ async def _get_additional_github_push_jsone_context(decision_link):
     commit_hash = get_revision(task, source_env_prefix)
 
     github_repo = GitHubRepository(repo_owner, repo_name, context.config["github_oauth_token"])
-    commit_data = await github_repo.get_commit(commit_hash)
+    commit_data = await github_repo.get_commit(commit_hash) or {}
 
     committer_login = commit_data.get("committer", {}).get("login")
     # https://github.com/mozilla-releng/scriptworker/issues/334: web-flow is the User used by

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (36, 0, 1)
+__version__ = (36, 0, 2)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version":[
         36,
         0,
-        1
+        2
     ],
-    "version_string":"36.0.1"
+    "version_string":"36.0.2"
 }


### PR DESCRIPTION
Fixes #477 .

We can either land and roll this out to support poorly-formed git commits, or we can require people have their git logins properly configured to pass CoT. I don't have strong opinions here, other than the former may save human debugging time.