### PR TITLE
add taskQueueId to the ignore list

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,21 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[36.0.3] - 2021-02-05
+---------------------
+
+Added
+~~~~~
+- Added a ``requirements.txt`` with unpinned requirements, for ronin-puppet pinning.
+
+Changed
+~~~~~~~
+- Updated ``ignore_keys`` to include the coming ``taskQueueId``.
+
+Fixed
+~~~~~
+- Removed esr68 prod cot tests
+
 [36.0.2] - 2021-01-15
 ---------------------
 

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -876,7 +876,7 @@ def verify_task_in_task_graph(task_link, graph_defn, level=logging.CRITICAL):
         CoTError: on failure
 
     """
-    ignore_keys = ("created", "deadline", "expires", "dependencies", "schedulerId")
+    ignore_keys = ("created", "deadline", "dependencies", "expires", "schedulerId", "taskQueueId")
     errors = []
     runtime_defn = deepcopy(task_link.task)
     # dependencies

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (36, 0, 2)
+__version__ = (36, 0, 3)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version":[
         36,
         0,
-        2
+        3
     ],
-    "version_string":"36.0.2"
+    "version_string":"36.0.3"
 }


### PR DESCRIPTION
Should address https://github.com/taskcluster/taskcluster/pull/4277 .
Once taskQueueId is everywhere on all tasks that we want to verify, we can remove it from the ignore list.