### PR TITLE
Add `projectId` to ignore keys

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[36.0.4] - 2021-02-09
+---------------------
+Changed
+~~~~~~~
+- Updated ``ignore_keys`` to include the coming ``projectId``.
+- Updated tests to use ``iscript>=5``
+
 [36.0.3] - 2021-02-05
 ---------------------
 

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -876,7 +876,7 @@ def verify_task_in_task_graph(task_link, graph_defn, level=logging.CRITICAL):
         CoTError: on failure
 
     """
-    ignore_keys = ("created", "deadline", "dependencies", "expires", "schedulerId", "taskQueueId")
+    ignore_keys = ("created", "deadline", "dependencies", "expires", "projectId", "schedulerId", "taskQueueId")
     errors = []
     runtime_defn = deepcopy(task_link.task)
     # dependencies

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (36, 0, 3)
+__version__ = (36, 0, 4)
 __version_string__ = get_version_string(__version__)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -76,12 +76,12 @@ commands=
 skip_install = true
 deps =
     black
-    isort
+    isort>=5
     flake8
     check-manifest
 commands =
     black --check {toxinidir}
-    isort --check -rc -df {toxinidir}
+    isort --check --df {toxinidir}
     flake8 {toxinidir}
     check-manifest -v {toxinidir}
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version":[
         36,
         0,
-        3
+        4
     ],
-    "version_string":"36.0.3"
+    "version_string":"36.0.4"
 }


### PR DESCRIPTION
Per #482.

Also address [isort >=5](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/).