### PR TITLE
[RELENG-42] add new scriptworker, docker-worker, and generic-worker cot keys

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,12 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[36.0.5] - 2021-02-11
+---------------------
+Changed
+~~~~~~~
+- Updated ``ed25519_public_keys`` with new public keys
+
 [36.0.4] - 2021-02-09
 ---------------------
 Changed

--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -80,9 +80,9 @@ DEFAULT_CONFIG = immutabledict(
         "ed25519_private_key_path": "...",
         "ed25519_public_keys": immutabledict(
             {
-                "docker-worker": tuple(["tk/SjxY3mREARba6ODw7qReUoVWj0RgEIxBURkwcM4I="]),
-                "generic-worker": tuple(["6UPrVTyw0EPQV7bCEMXo+5jNR4clbK55JWG74bBJHZQ="]),
-                "scriptworker": tuple(["DaEKQ79ZC/X+7O8zwm8iyhwTlgyjRSi/TDd63fh2JG0="]),
+                "docker-worker": tuple(["tk/SjxY3mREARba6ODw7qReUoVWj0RgEIxBURkwcM4I=", "eqrans05OJsBr3KaDHMRyZHKOVQ3nURfz4pRaQ6a5xc="]),
+                "generic-worker": tuple(["6UPrVTyw0EPQV7bCEMXo+5jNR4clbK55JWG74bBJHZQ=", "tHBwAdz8mK6Fnh7RwmfVh6Kzv1suwp+CFW2fvvTLpwE="]),
+                "scriptworker": tuple(["DaEKQ79ZC/X+7O8zwm8iyhwTlgyjRSi/TDd63fh2JG0=", "N2fb7t0z06GxeidHYDZ63cz2wE2aDA4Hjm7u+FKladc="]),
             }
         ),
         "project_configuration_url": "https://hg.mozilla.org/ci/ci-configuration/raw-file/default/projects.yml",

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (36, 0, 4)
+__version__ = (36, 0, 5)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version":[
         36,
         0,
-        4
+        5
     ],
-    "version_string":"36.0.4"
+    "version_string":"36.0.5"
 }


### PR DESCRIPTION
The docker-worker keypair isn't 100% guaranteed to stay the same, but let's roll this out in case it is. At least we'll mark the scriptworker+generic-worker keys valid.