### PR TITLE
arrow timestamp -> int_timestamp

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,12 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[37.0.2] - 2021-03-08
+---------------------
+Fixed
+~~~~~
+- ``timestamp`` -> ``int_timestamp`` in arrow calls; set min arrow version to 1.0
+
 [37.0.1] - 2021-02-19
 ---------------------
 Changed

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`__.
 Fixed
 ~~~~~
 - ``timestamp`` -> ``int_timestamp`` in arrow calls; set min arrow version to 1.0
+- production tests no longer require the taskcluster proxy.
 
 [37.0.1] - 2021-02-19
 ---------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ immutabledict
 jsonschema
 json-e>=2.5.0
 PyYAML
-taskcluster>=4.0.0
+taskcluster<40

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3
 aiomemoizettl
-arrow
+arrow>=1.0
 cryptography>=2.6.1
 dictdiffer
 github3.py

--- a/src/scriptworker/context.py
+++ b/src/scriptworker/context.py
@@ -122,7 +122,7 @@ class Context(object):
     def credentials(self, creds):
         self._credentials = creds
         self.queue = self.create_queue(self.credentials)
-        self.credentials_timestamp = arrow.utcnow().timestamp
+        self.credentials_timestamp = arrow.utcnow().int_timestamp
 
     @property
     def task_id(self):

--- a/src/scriptworker/utils.py
+++ b/src/scriptworker/utils.py
@@ -109,7 +109,7 @@ def datestring_to_timestamp(datestring):
         int: the corresponding timestamp.
 
     """
-    return arrow.get(datestring).timestamp
+    return arrow.get(datestring).int_timestamp
 
 
 # to_unicode {{{1

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (37, 0, 1)
+__version__ = (37, 0, 2)
 __version_string__ = get_version_string(__version__)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -109,7 +109,7 @@ def populate_credentials(config, sources, start=None):
     start = start or arrow.utcnow().shift(minutes=-20)
     for count, path in enumerate(sources):
         new_time = start.shift(minutes=count)
-        copyfile(path, os.path.join(config["work_dir"], "credentials.{}.json".format(new_time.timestamp)))
+        copyfile(path, os.path.join(config["work_dir"], "credentials.{}.json".format(new_time.int_timestamp)))
 
 
 def no_sleep(*args, **kwargs):

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -56,6 +56,11 @@ async def build_config(override, basedir):
 
 
 async def _get_github_token():
+    if os.environ.get("SCRIPTWORKER_GITHUB_TOKEN"):
+        return os.environ["SCRIPTWORKER_GITHUB_TOKEN"]
+    token = read_worker_creds(key="scriptworker_github_token")
+    if token:
+        return read_worker_creds(key="scriptworker_github_token")
     try:
         root_url = os.environ["TASKCLUSTER_PROXY_URL"]
     except KeyError as e:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -181,7 +181,7 @@ def test_get_worker_type(task, result):
     (
         ("https://hg.mozilla.org/mozilla-central", "mozilla-central", False, "firefox"),
         ("https://hg.mozilla.org/projects/foo", "foo", True, "firefox"),
-        ("https://hg.mozilla.org/releases/mozilla-esr68", "mozilla-esr68", False, "firefox"),
+        ("https://hg.mozilla.org/releases/mozilla-esr78", "mozilla-esr78", False, "firefox"),
         ("https://hg.mozilla.org/try", "try", False, "firefox"),
         ("https://hg.mozilla.org/releases/unknown", "unknown", True, "firefox"),
         ("https://hg.mozilla.org/users/mozilla_hocat.ca/esr60-stage/", "", True, "firefox"),
@@ -473,10 +473,10 @@ async def test_run_task_timeout(context):
     # create all 6 files
     context.config["task_max_timeout"] = 5
 
-    pre = arrow.utcnow().timestamp
+    pre = arrow.utcnow().int_timestamp
     with pytest.raises(ScriptWorkerTaskException):
         await swtask.run_task(context, noop_to_cancellable_process)
-    post = arrow.utcnow().timestamp
+    post = arrow.utcnow().int_timestamp
     # I don't love these checks, because timing issues may cause this test
     # to be flaky. However, I don't want a non- or long- running test to pass.
     # Did this run at all?

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -26,7 +26,7 @@ from . import AT_LEAST_PY38, TIMEOUT_SCRIPT, create_async, create_finished_futur
 # constants helpers and fixtures {{{1
 @pytest.yield_fixture(scope="function")
 def context(rw_context):
-    rw_context.credentials_timestamp = arrow.utcnow().shift(minutes=-10).timestamp
+    rw_context.credentials_timestamp = arrow.utcnow().shift(minutes=-10).int_timestamp
     yield rw_context
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version":[
         37,
         0,
-        1
+        2
     ],
-    "version_string":"37.0.1"
+    "version_string":"37.0.2"
 }


### PR DESCRIPTION
https://github.com/mozilla-releng/scriptworker-scripts/pull/337/files will break on deploy unless we also fix scriptworker's timestamp usage.