### PR TITLE
Docker worker cot

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[37.0.3] - 2021-04-14
+---------------------
+Changed
+~~~~~~~
+- Replaced the new docker-worker pubkey in ``ed25519_public_keys``: we never used the previous-new keypair, and we're rolling out this keypair.
+- Added mypy typing to ``scriptworker.context``
+
 [37.0.2] - 2021-03-08
 ---------------------
 Fixed

--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -80,7 +80,7 @@ DEFAULT_CONFIG = immutabledict(
         "ed25519_private_key_path": "...",
         "ed25519_public_keys": immutabledict(
             {
-                "docker-worker": tuple(["tk/SjxY3mREARba6ODw7qReUoVWj0RgEIxBURkwcM4I=", "eqrans05OJsBr3KaDHMRyZHKOVQ3nURfz4pRaQ6a5xc="]),
+                "docker-worker": tuple(["tk/SjxY3mREARba6ODw7qReUoVWj0RgEIxBURkwcM4I=", "1cnK7Qc2wjL9Dl7XTBgNE9Ns+NWHraCE5qfxblEKg8A="]),
                 "generic-worker": tuple(["6UPrVTyw0EPQV7bCEMXo+5jNR4clbK55JWG74bBJHZQ=", "tHBwAdz8mK6Fnh7RwmfVh6Kzv1suwp+CFW2fvvTLpwE="]),
                 "scriptworker": tuple(["DaEKQ79ZC/X+7O8zwm8iyhwTlgyjRSi/TDd63fh2JG0=", "N2fb7t0z06GxeidHYDZ63cz2wE2aDA4Hjm7u+FKladc="]),
             }

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (37, 0, 2)
+__version__ = (37, 0, 3)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version":[
         37,
         0,
-        2
+        3
     ],
-    "version_string":"37.0.2"
+    "version_string":"37.0.3"
 }


### PR DESCRIPTION
We never used the previous-new docker-worker CoT key. We're rolling out a new docker-worker CoT key; let's allowlist the pubkey.