### PR TITLE
pytest asyncio 0.15.1 is broken too

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     mock
     pytest
     # https://github.com/pytest-dev/pytest-asyncio/issues/209
-    pytest-asyncio!=0.15.0
+    pytest-asyncio<0.15
     pytest-cov
     pytest-mock
     pytest-random-order


### PR DESCRIPTION
https://github.com/pytest-dev/pytest-asyncio/issues/209 didn't end up fixing the issue, so let's pin `pytest-asyncio<0.15.0`