### PR TITLE
Scriptworker 38.0.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,28 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[38.0.0] - 2021-05-17
+---------------------
+Removed
+~~~~~~~
+- Removed py36 support
+- Removed obsolete mobile production tests
+
+Added
+~~~~~
+- Added py39 support
+
+Changed
+~~~~~~~
+- Require ``immutabledict>=1.3.0`` to avoid typing bustage
+- Require ``taskcluster<41`` instead of ``taskcluster<40`` to match the latest cluster version
+- CoT verification now supports ``projectId`` and ``taskQueueId``.
+- Pinned to ``pytest-asyncio<0.15`` due to production test bustage
+
+Fixed
+~~~~~
+- Fixed immutabledict typing bustage
+
 [37.0.3] - 2021-04-14
 ---------------------
 Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ immutabledict>=1.3.0
 jsonschema
 json-e>=2.5.0
 PyYAML
-taskcluster<40
+taskcluster<41

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (37, 0, 3)
+__version__ = (38, 0, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -144,21 +144,6 @@ VERIFY_COT_BRANCH_CONTEXTS = (
         "cot_product": "mobile",
     },
     {
-        "name": "fenix production",
-        "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        "index": "mobile.v2.fenix.fennec-production.latest.arm64-v8a",
-        "task_type": "signing",
-        "cot_product": "mobile",
-    },
-    {
-        "name": "fenix performance tests",
-        "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        "index": "mobile.v2.fenix.performance-test.latest.arm64-v8a",
-        "task_type": "signing",
-        "cot_product": "mobile",
-        "check_task": False,  # These tasks run on level t workers.
-    },
-    {
         "name": "reference-browser nightly",
         "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
         "index": "mobile.v2.reference-browser.nightly.latest.arm64-v8a",

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
-        37,
+        38,
         0,
-        3
+        0
     ],
-    "version_string":"37.0.3"
+    "version_string":"38.0.0"
 }


### PR DESCRIPTION
Once we roll this out, this should unblock the firefoxci taskcluster 41.x upgrade.