### PR TITLE
remove old cot keys

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -47,7 +47,7 @@ tasks:
            ['py39-cot', 'python:3.9', {
                 NO_CREDENTIALS_TESTS: '1',
             }, ['secrets:get:repo:github.com/mozilla-releng/scriptworker:github']],
-           ['lint', 'python:3.7', {}, []],
+           ['check', 'python:3.7', {}, []],
            ['mypy', 'python:3.7', {}, []]]
     each(py):
       taskId: "${as_slugid(py[0])}"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,16 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+[39.0.0] - 2021-08-05
+---------------------
+Changed
+~~~~~~~
+- Removed old CoT keys
+- ``lint`` tox target renamed to ``check`` to match other releng repos
+- Tests now use ``coveralls`` instead of ``pytest-coveralls``
+- fixed ``fenix`` prod cot index; old one hadn't been updated in a year
+- added ``adhoc-signing`` and ``xpi-manifest`` cot index tests
+
 [38.2.0] - 2021-07-14
 ---------------------
 Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ immutabledict>=1.3.0
 jsonschema
 json-e>=2.5.0
 PyYAML
-taskcluster<41
+taskcluster

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,6 @@ if {"register", "upload"}.intersection(set(sys.argv)):
 
 tests_require = [
     "asyncio_extras",
-    # TODO Remove the condition on coverage once
-    # https://github.com/z4r/python-coveralls/issues/73 is fixed
-    "coverage<5",
     "flake8",
     "flake8_docstrings",
     "mock",

--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -80,9 +80,9 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
         "ed25519_private_key_path": "...",
         "ed25519_public_keys": immutabledict(
             {
-                "docker-worker": tuple(["tk/SjxY3mREARba6ODw7qReUoVWj0RgEIxBURkwcM4I=", "1cnK7Qc2wjL9Dl7XTBgNE9Ns+NWHraCE5qfxblEKg8A="]),
-                "generic-worker": tuple(["6UPrVTyw0EPQV7bCEMXo+5jNR4clbK55JWG74bBJHZQ=", "tHBwAdz8mK6Fnh7RwmfVh6Kzv1suwp+CFW2fvvTLpwE="]),
-                "scriptworker": tuple(["DaEKQ79ZC/X+7O8zwm8iyhwTlgyjRSi/TDd63fh2JG0=", "N2fb7t0z06GxeidHYDZ63cz2wE2aDA4Hjm7u+FKladc="]),
+                "docker-worker": tuple(["1cnK7Qc2wjL9Dl7XTBgNE9Ns+NWHraCE5qfxblEKg8A="]),
+                "generic-worker": tuple(["tHBwAdz8mK6Fnh7RwmfVh6Kzv1suwp+CFW2fvvTLpwE="]),
+                "scriptworker": tuple(["N2fb7t0z06GxeidHYDZ63cz2wE2aDA4Hjm7u+FKladc="]),
             }
         ),
         "project_configuration_url": "https://hg.mozilla.org/ci/ci-configuration/raw-file/default/projects.yml",

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (38, 2, 0)
+__version__ = (39, 0, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -139,7 +139,7 @@ VERIFY_COT_BRANCH_CONTEXTS = (
     {
         "name": "fenix beta",
         "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        "index": "mobile.v2.fenix.fennec-beta.latest.arm64-v8a",
+        "index": "mobile.v2.fenix.beta.latest.arm64-v8a",
         "task_type": "signing",
         "cot_product": "mobile",
     },
@@ -157,6 +157,20 @@ VERIFY_COT_BRANCH_CONTEXTS = (
         "task_type": "signing",
         "cot_product": "mobile",
         "check_task": False,  # These tasks run on level t workers.
+    },
+    {
+        "name": "adhoc-signing",
+        "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
+        "index": "adhoc.v2.adhoc-signing.2021-07-28-vpn-2.4.1-msi-2.release-signing.latest",
+        "task_type": "signing",
+        "cot_product": "adhoc",
+    },
+    {
+        "name": "xpi-manifest reset-search-default",
+        "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
+        "index": "xpi.v2.xpi-manifest.reset-search-default-extension.release-signing.latest",
+        "task_type": "signing",
+        "cot_product": "xpi",
     },
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,mypy,py37,py37-cot,py38,py38-cot,py39,py39-cot
+envlist = check,mypy,py37,py37-cot,py38,py38-cot,py39,py39-cot
 
 [testenv]
 depends = clean
@@ -78,7 +78,7 @@ commands=
     python setup.py develop
     py.test -k test_verify_production_cot --random-order-bucket=none
 
-[testenv:lint]
+[testenv:check]
 skip_install = true
 deps =
     black

--- a/tox.ini
+++ b/tox.ini
@@ -12,16 +12,11 @@ passenv =
     NO_TESTS_OVER_WIRE
     NO_CREDENTIALS_TESTS
     TASKCLUSTER_PROXY_URL
-    TRAVIS
-    TRAVIS_JOB_ID
-    TRAVIS_BRANCH
 
 deps =
     aiohttp>=3
     asyncio_extras
-    # TODO Remove the condition on coverage once
-    # https://github.com/z4r/python-coveralls/issues/73 is fixed
-    coverage<5
+    coveralls
     flake8
     pydocstyle==3.0.0
     flake8_docstrings
@@ -29,7 +24,6 @@ deps =
     pytest
     # https://github.com/pytest-dev/pytest-asyncio/issues/209
     pytest-asyncio<0.15
-    pytest-cov
     pytest-mock
     pytest-random-order
     virtualenv
@@ -37,31 +31,31 @@ deps =
 usedevelop = true
 
 commands=
-    {posargs:py.test --cov-config=tox.ini --cov-append --cov=scriptworker --cov-report term-missing tests}
+    {posargs:coverage run --source=src/scriptworker --branch --rcfile tox.ini -m pytest tests}
 
 [testenv:clean]
 skip_install = true
 commands = coverage erase
+deps=
+    coveralls
 depends =
 
 [testenv:report]
 skip_install = true
 commands = coverage report -m
 depends = py38
+deps=
+    coveralls
 parallel_show_output = true
 
 [testenv:coveralls]
 passenv =
     COVERALLS_REPO_TOKEN
-    TRAVIS_JOB_ID
     COVERALLS_SERVICE_NAME
 deps=
-    python-coveralls
-    # TODO Remove the condition on coverage once
-    # https://github.com/z4r/python-coveralls/issues/73 is fixed
-    coverage<5
-commands=
     coveralls
+commands=
+    coveralls --service=taskcluster
 
 [testenv:py37-cot]
 commands=

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
-        38,
-        2,
+        39,
+        0,
         0
     ],
-    "version_string":"38.2.0"
+    "version_string":"39.0.0"
 }


### PR DESCRIPTION
~The prod tests will show us when the latest release/nightly graphs are all based on tasks using the new keys; let's not merge until these are green, or we explicitly determine that we don't need to wait on a given bustage.~

Green! I had to adjust our test configs to get this green due to #509, but this now fixes #509 as well.