### PR TITLE
Fix claimWork in scriptworker + tc>39

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ immutabledict>=1.3.0
 jsonschema
 json-e>=2.5.0
 PyYAML
-taskcluster
+taskcluster>39

--- a/src/scriptworker/config.py
+++ b/src/scriptworker/config.py
@@ -12,7 +12,7 @@ import logging
 import os
 import re
 import sys
-from collections import Mapping
+from collections.abc import Mapping
 from copy import deepcopy
 
 from immutabledict import immutabledict

--- a/src/scriptworker/task.py
+++ b/src/scriptworker/task.py
@@ -746,6 +746,6 @@ async def claim_work(context):
         "tasks": 1,
     }
     try:
-        return await context.queue.claimWork(context.config["provisioner_id"], context.config["worker_type"], payload)
+        return await context.queue.claimWork(f"{context.config['provisioner_id']}/{context.config['worker_type']}", payload)
     except (taskcluster.exceptions.TaskclusterFailure, aiohttp.ClientError, asyncio.TimeoutError) as exc:
         log.warning("{} {}".format(exc.__class__, exc))


### PR DESCRIPTION
The API for `claimWork` changed in Taskcluster 40.
This PR greens up the integration tests when we use taskcluster 44.1.0.

As a followup, we should create a long-lived test client like https://firefox-ci-tc.services.mozilla.com/auth/clients/mozilla-auth0%2Fad|Mozilla-LDAP|asasaki%2Fworker-test , put it in TC secrets, and use that to run integration tests in this repo.