### PR TITLE
Add scope constants for microsoftstore / pushmsixscript.

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -337,6 +337,8 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                             "project:releng:flathub:firefox:stable": "release",
                             "project:releng:ship-it:production": "all-production-branches",
                             "project:releng:treescript:action:push": "all-production-branches",
+                            "project:releng:microsoftstore:beta": "beta",
+                            "project:releng:microsoftstore:release": "release",
                         }
                     ),
                     "thunderbird": immutabledict(


### PR DESCRIPTION
Follow-up on a review comment from the pushmsixscript PR.

These scopes match those in pushmsixscript. Now that I see them in this list, I wonder, should they contain ":firefox"?