### PR TITLE
unpin pytest-asyncio

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,8 +60,7 @@ class UnsuccessfulQueue(object):
 
 
 @pytest.fixture(scope="function")
-def event_loop(request):
-    request.param
+def event_loop():
     loop = asyncio.new_event_loop()
     yield loop
     loop.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,14 @@ class UnsuccessfulQueue(object):
 
 
 @pytest.fixture(scope="function")
+def event_loop(request):
+    request.param
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="function")
 def successful_queue():
     return SuccessfulQueue()
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,7 @@ deps =
     flake8_docstrings
     mock
     pytest
-    # https://github.com/pytest-dev/pytest-asyncio/issues/209
-    pytest-asyncio<0.15
+    pytest-asyncio
     pytest-mock
     pytest-random-order
     virtualenv


### PR DESCRIPTION
I pinned pytest-asyncio to deal with https://github.com/pytest-dev/pytest-asyncio/issues/209; unpinning to see if we're still broken with recent releases.