### PR TITLE
RELENG-830 - add the 2022 generic-worker trusted CoT public key

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -84,7 +84,14 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
         "ed25519_public_keys": immutabledict(
             {
                 "docker-worker": tuple(["1cnK7Qc2wjL9Dl7XTBgNE9Ns+NWHraCE5qfxblEKg8A="]),
-                "generic-worker": tuple(["tHBwAdz8mK6Fnh7RwmfVh6Kzv1suwp+CFW2fvvTLpwE="]),
+                "generic-worker": tuple(
+                    [
+                        # 2021 key; remove when we've finished migrating to the new key
+                        "tHBwAdz8mK6Fnh7RwmfVh6Kzv1suwp+CFW2fvvTLpwE=",
+                        # 2022 key, RELENG-827
+                        "IxbFWmV+MwHRQFOO6TDUfSsYA1Og+M/fpkpjuX5X5gg=",
+                    ]
+                ),
                 "scriptworker": tuple(["N2fb7t0z06GxeidHYDZ63cz2wE2aDA4Hjm7u+FKladc="]),
             }
         ),


### PR DESCRIPTION
From [Mana - Chain of Trust key rotation](https://mana.mozilla.org/wiki/display/RelEng/Chain+of+Trust+key+rotation?flashId=459232040)

- [RELENG-827 - generate a new generic-worker CoT key](https://mozilla-hub.atlassian.net/browse/RELENG-827)
  - [RELOPS-123 - Update gecko-3-b-win2012 images with new CoT key](
https://mozilla-hub.atlassian.net/browse/RELOPS-123)
- [RELENG-830 - mark the new keys as trusted](https://mozilla-hub.atlassian.net/browse/RELENG-830)

Aiui Relops will roll this key out to all generic-worker pools.