### PR TITLE
fix cot test

### DIFF
--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -161,7 +161,7 @@ VERIFY_COT_BRANCH_CONTEXTS = (
     {
         "name": "adhoc-signing",
         "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        "index": "adhoc.v2.adhoc-signing.2021-07-28-vpn-2.4.1-msi-2.release-signing.latest",
+        "index": "adhoc.v2.adhoc-signing.bug1774221-3.release-signing.latest",
         "task_type": "signing",
         "cot_product": "adhoc",
     },

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -166,9 +166,9 @@ VERIFY_COT_BRANCH_CONTEXTS = (
         "cot_product": "adhoc",
     },
     {
-        "name": "xpi-manifest reset-search-default",
+        "name": "xpi-manifest firefox-translations",
         "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        "index": "xpi.v2.xpi-manifest.reset-search-default-extension.release-signing.latest",
+        "index": "xpi.v2.xpi-manifest.firefox-translations.release-signing.latest",
         "task_type": "signing",
         "cot_product": "xpi",
     },


### PR DESCRIPTION
I'm guessing the old one hasn't been released in over a year.
I went to shipit to find recent xpi releases and chose the most recent.
Adhoc I looked at the index list and chose something 1 month old I think.

We could potentially mitigate this in the future by adding a generic "latest-release-signing-task-of-any-variety" index to both xpi and adhoc, and pointing at that.