### PR TITLE
scriptworker 43.5.0 (with actual version bump)

### DIFF
--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (43, 4, 0)
+__version__ = (43, 5, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
         43,
-        4,
+        5,
         0
     ],
-    "version_string":"43.4.0"
+    "version_string":"43.5.0"
 }


### PR DESCRIPTION
I forgot to bump versions in https://github.com/mozilla-releng/scriptworker/commit/e625940312cb85a05a4e2a5728bb1640e3d61b23 😅 

I just released https://pypi.org/project/scriptworker/43.5.0/ with this patch.