### PR TITLE
Bug 1786838 - Allow comm-central to use production bouncer scope.

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -372,7 +372,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                             "project:comm:thunderbird:releng:balrog:server:esr": "esr",
                             "project:comm:thunderbird:releng:beetmover:bucket:nightly": "all-nightly-branches",
                             "project:comm:thunderbird:releng:beetmover:bucket:release": "all-release-branches",
-                            "project:comm:thunderbird:releng:bouncer:server:production": "all-release-branches",
+                            "project:comm:thunderbird:releng:bouncer:server:production": "all-nightly-branches",
                             "project:comm:thunderbird:releng:signing:cert:nightly-signing": "all-nightly-branches",
                             "project:comm:thunderbird:releng:signing:cert:release-signing": "all-release-branches",
                         }


### PR DESCRIPTION
The scope is used by the "bouncer-locations" on comm-central to
keep the Thunderbird Daily bouncer products pointing to the
latest version.