### PR TITLE
Allow tasks for action in Mozilla VPN

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -299,7 +299,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                         "github-push",
                         "github-release",
                     ),
-                    "mozillavpn": ("cron", "github-pull-request", "github-push", "github-release"),
+                    "mozillavpn": ("cron", "github-pull-request", "github-push", "github-release", "action"),
                     "app-services": (
                         "action",
                         "cron",


### PR DESCRIPTION
This is for the Mozilla VPN release promotion action

https://firefox-ci-tc.services.mozilla.com/tasks/EhSwy_MJSfakY0skY8bnUg/runs/0/logs/public/logs/chain_of_trust.log