### PR TITLE
Bug 1786780 - Restrict A-C scopes to both A-C and firefox-android repos

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,12 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+43.8.0 - TBD
+-------------------
+Added
+~~~~~
+- Restricted Android-Components scopes to both `android-components` and `firefox-android` repos
+
 43.7.0 - 2022-09-14
 -------------------
 Added

--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -224,9 +224,11 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                                     [
                                         r"^(?P<path>/mozilla-mobile/"
                                         "(?:"
+                                        # TODO Bug 1791397 - Remove A-C repo once it's migrated to the monorepo
                                         "android-components"
                                         "|fenix"
                                         "|fennec-profile-manager"
+                                        "|firefox-android"
                                         "|firefox-tv"
                                         "|focus-android"
                                         "|reference-browser"
@@ -379,6 +381,12 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                     ),
                     "mobile": immutabledict(
                         {
+                            "project:mobile:firefox-android:releng:github:project:firefox-android": "firefox-android-repo",
+                            "project:mobile:firefox-android:releng:beetmover:bucket:maven-production": "firefox-android-repo",
+                            "project:mobile:firefox-android:releng:beetmover:bucket:maven-snapshot-production": "firefox-android-repo",
+                            "project:mobile:firefox-android:releng:signing:cert:release-signing": "firefox-android-repo",
+                            # TODO Bug 1791397 - Remove A-C scopes once it's migrated to the monorepo
+                            # (we will then do the same with Fenix and Focus-Android)
                             "project:mobile:android-components:releng:github:project:android-components": "android-components-repo",
                             "project:mobile:android-components:releng:beetmover:bucket:maven-production": "android-components-repo",
                             "project:mobile:android-components:releng:beetmover:bucket:maven-snapshot-production": "android-components-repo",
@@ -500,9 +508,11 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                     ),
                     "mobile": immutabledict(
                         {
+                            # TODO Bug 1791397 - Remove A-C repo once it's migrated to the monorepo
                             "android-components-repo": ("/mozilla-mobile/android-components",),
                             "fenix-repo": ("/mozilla-mobile/fenix",),
                             "fennec-profile-manager-repo": ("/mozilla-mobile/fennec-profile-manager",),
+                            "firefox-android-repo": ("/mozilla-mobile/firefox-android",),
                             "firefox-tv-repo": ("/mozilla-mobile/firefox-tv",),
                             "focus-repo": ("/mozilla-mobile/focus-android",),
                             "reference-browser-repo": ("/mozilla-mobile/reference-browser",),


### PR DESCRIPTION
Context: @escapewindow reminded me of this type of change in https://github.com/mozilla-releng/scriptworker-scripts/pull/565#discussion_r974524753