### PR TITLE
Bug 1791397 - Remove all references to android-components

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,12 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+45.0.0 - 2022-11-23
+-------------------
+Removed
+~~~~~~~
+- Android-Components references. This repository is not supported anymore.
+
 44.2.0 - 2022-10-25
 -------------------
 Added

--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -238,9 +238,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                                     [
                                         r"^(?P<path>/mozilla-mobile/"
                                         "(?:"
-                                        # TODO Bug 1791397 - Remove A-C repo once it's migrated to the monorepo
-                                        "android-components"
-                                        "|fenix"
+                                        "fenix"
                                         "|fennec-profile-manager"
                                         "|firefox-android"
                                         "|firefox-tv"
@@ -399,11 +397,6 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                             "project:mobile:firefox-android:releng:beetmover:bucket:maven-production": "firefox-android-repo",
                             "project:mobile:firefox-android:releng:beetmover:bucket:maven-snapshot-production": "firefox-android-repo",
                             "project:mobile:firefox-android:releng:signing:cert:release-signing": "firefox-android-repo",
-                            # TODO Bug 1791397 - Remove A-C scopes once it's migrated to the monorepo
-                            # (we will then do the same with Fenix and Focus-Android)
-                            "project:mobile:android-components:releng:github:project:android-components": "android-components-repo",
-                            "project:mobile:android-components:releng:beetmover:bucket:maven-production": "android-components-repo",
-                            "project:mobile:android-components:releng:beetmover:bucket:maven-snapshot-production": "android-components-repo",
                             "project:mobile:fenix:releng:github:project:fenix": "fenix-repo",
                             "project:mobile:fenix:releng:googleplay:product:fenix": "fenix-repo",
                             "project:mobile:fenix:releng:signing:cert:nightly-signing": "fenix-repo",
@@ -512,8 +505,6 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                     ),
                     "mobile": immutabledict(
                         {
-                            # TODO Bug 1791397 - Remove A-C repo once it's migrated to the monorepo
-                            "android-components-repo": ("/mozilla-mobile/android-components",),
                             "fenix-repo": ("/mozilla-mobile/fenix",),
                             "fennec-profile-manager-repo": ("/mozilla-mobile/fennec-profile-manager",),
                             "firefox-android-repo": ("/mozilla-mobile/firefox-android",),

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -271,13 +271,13 @@ def test_is_github_url(url, expected):
 @pytest.mark.parametrize(
     "repo_url, expected_user, expected_repo_name, raises",
     (
-        ("https://github.com/mozilla-mobile/android-components", "mozilla-mobile", "android-components", False),
-        ("https://github.com/mozilla-mobile/android-components.git", "mozilla-mobile", "android-components", False),
-        ("https://github.com/JohanLorenzo/android-components", "JohanLorenzo", "android-components", False),
+        ("https://github.com/mozilla-mobile/firefox-android", "mozilla-mobile", "firefox-android", False),
+        ("https://github.com/mozilla-mobile/firefox-android.git", "mozilla-mobile", "firefox-android", False),
+        ("https://github.com/mozilla-releng/staging-firefox-android", "mozilla-releng", "staging-firefox-android", False),
         (
-            "https://github.com/JohanLorenzo/android-components/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml",
-            "JohanLorenzo",
-            "android-components",
+            "https://github.com/mozilla-releng/staging-firefox-android/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml",
+            "mozilla-releng",
+            "staging-firefox-android",
             False,
         ),
         ("https://hg.mozilla.org/mozilla-central", None, None, True),
@@ -294,12 +294,12 @@ def test_extract_github_repo_owner_and_name(repo_url, expected_user, expected_re
 @pytest.mark.parametrize(
     "repo_url, expected, raises",
     (
-        ("https://github.com/mozilla-mobile/android-components", "mozilla-mobile/android-components", False),
-        ("https://github.com/mozilla-mobile/android-components.git", "mozilla-mobile/android-components", False),
-        ("https://github.com/JohanLorenzo/android-components", "JohanLorenzo/android-components", False),
+        ("https://github.com/mozilla-mobile/firefox-android", "mozilla-mobile/firefox-android", False),
+        ("https://github.com/mozilla-mobile/firefox-android.git", "mozilla-mobile/firefox-android", False),
+        ("https://github.com/mozilla-releng/staging-firefox-android", "mozilla-releng/staging-firefox-android", False),
         (
-            "https://github.com/JohanLorenzo/android-components/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml",
-            "JohanLorenzo/android-components",
+            "https://github.com/mozilla-releng/staging-firefox-android/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml",
+            "mozilla-releng/staging-firefox-android",
             False,
         ),
         ("https://hg.mozilla.org/mozilla-central", None, True),
@@ -316,12 +316,12 @@ def test_extract_github_repo_full_name(repo_url, expected, raises):
 @pytest.mark.parametrize(
     "repo_url, expected, raises",
     (
-        ("https://github.com/mozilla-mobile/android-components", "git@github.com:mozilla-mobile/android-components.git", False),
-        ("https://github.com/mozilla-mobile/android-components.git", "git@github.com:mozilla-mobile/android-components.git", False),
-        ("https://github.com/JohanLorenzo/android-components", "git@github.com:JohanLorenzo/android-components.git", False),
+        ("https://github.com/mozilla-mobile/firefox-android", "git@github.com:mozilla-mobile/firefox-android.git", False),
+        ("https://github.com/mozilla-mobile/firefox-android.git", "git@github.com:mozilla-mobile/firefox-android.git", False),
+        ("https://github.com/mozilla-releng/staging-firefox-android", "git@github.com:mozilla-releng/staging-firefox-android.git", False),
         (
-            "https://github.com/JohanLorenzo/android-components/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml",
-            "git@github.com:JohanLorenzo/android-components.git",
+            "https://github.com/mozilla-releng/staging-firefox-android/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml",
+            "git@github.com:mozilla-releng/staging-firefox-android.git",
             False,
         ),
         ("https://hg.mozilla.org/mozilla-central", None, True),
@@ -339,20 +339,20 @@ def test_extract_github_repo_ssh_url(repo_url, expected, raises):
     "repo_url, expected_user, expected_repo_name, raises",
     (
         (
-            "https://github.com/JohanLorenzo/android-components/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml",
-            "https://github.com/JohanLorenzo/android-components",
+            "https://github.com/mozilla-releng/staging-firefox-android/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml",
+            "https://github.com/mozilla-releng/staging-firefox-android",
             "0123456789abcdef0123456789abcdef01234567",
             False,
         ),
         (
-            "https://github.com/JohanLorenzo/android-components.git/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml",
-            "https://github.com/JohanLorenzo/android-components",
+            "https://github.com/mozilla-releng/staging-firefox-android.git/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml",
+            "https://github.com/mozilla-releng/staging-firefox-android",
             "0123456789abcdef0123456789abcdef01234567",
             False,
         ),
-        ("https://github.com/mozilla-mobile/android-components", None, None, True),
-        ("https://github.com/mozilla-mobile/android-components.git", None, None, True),
-        ("https://github.com/JohanLorenzo/android-components", None, None, True),
+        ("https://github.com/mozilla-mobile/firefox-android", None, None, True),
+        ("https://github.com/mozilla-mobile/firefox-android.git", None, None, True),
+        ("https://github.com/mozilla-releng/staging-firefox-android", None, None, True),
         ("https://hg.mozilla.org/mozilla-central", None, None, True),
     ),
 )


### PR DESCRIPTION
Just like https://github.com/mozilla-releng/scriptworker-scripts/pull/591, `git grep android-components` gave me all the places I needed to change.