### PR TITLE
[RELENG-837] - Remove 2021 CoT keys

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -85,24 +85,18 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
             {
                 "docker-worker": tuple(
                     [
-                        # 2021 key; remove when we've finished migrating to the new key
-                        "1cnK7Qc2wjL9Dl7XTBgNE9Ns+NWHraCE5qfxblEKg8A=",
                         # 2022 key, RELENG-830
                         "YM4whpr6pGNnF+LHUGWZPgDXiWOTdEQwctTr4LyeO/Q=",
                     ]
                 ),
                 "generic-worker": tuple(
                     [
-                        # 2021 key; remove when we've finished migrating to the new key
-                        "tHBwAdz8mK6Fnh7RwmfVh6Kzv1suwp+CFW2fvvTLpwE=",
                         # 2022 key, RELENG-827
                         "IxbFWmV+MwHRQFOO6TDUfSsYA1Og+M/fpkpjuX5X5gg=",
                     ]
                 ),
                 "scriptworker": tuple(
                     [
-                        # 2021 key; remove when we've finished migrating to the new key
-                        "N2fb7t0z06GxeidHYDZ63cz2wE2aDA4Hjm7u+FKladc=",
                         # 2022 key, RELENG-828
                         "uJhnk8irgYrkrcxnJUdfIsJo3gntBL+jvZNhNt/pJ/0=",
                     ]

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -161,21 +161,30 @@ VERIFY_COT_BRANCH_CONTEXTS = (
     {
         "name": "adhoc-signing",
         "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        "index": "adhoc.v2.adhoc-signing.bug1774221-3.release-signing.latest",
+        "index": "adhoc.v2.adhoc-signing.bug1799220.release-signing.latest",
         "task_type": "signing",
         "cot_product": "adhoc",
     },
-    {
-        "name": "xpi-manifest firefox-translations",
-        "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        "index": "xpi.v2.xpi-manifest.firefox-translations.release-signing.latest",
-        "task_type": "signing",
-        "cot_product": "xpi",
-    },
+    pytest.param(
+        {
+            "name": "xpi-manifest firefox-translations",
+            "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
+            "index": "xpi.v2.xpi-manifest.firefox-translations.release-signing.latest",
+            "task_type": "signing",
+            "cot_product": "xpi",
+        },
+        # should start passing again once there has been a new release of the
+        # firefox-translations addon
+        marks=pytest.mark.xfail,
+    ),
 )
 
 
-@pytest.mark.parametrize("branch_context", VERIFY_COT_BRANCH_CONTEXTS, ids=[bc["name"] for bc in VERIFY_COT_BRANCH_CONTEXTS])
+def idfn(obj):
+    return obj["name"]
+
+
+@pytest.mark.parametrize("branch_context", VERIFY_COT_BRANCH_CONTEXTS, ids=idfn)
 @pytest.mark.asyncio
 async def test_verify_production_cot(branch_context):
     index = Index(options={"rootUrl": branch_context["taskcluster_root_url"]})


### PR DESCRIPTION
There haven't been any xpi-manifest releases recently, so that test is still failing and I marked it as xfail. Once there has been a release, we can change the index to point at it and remove the xfail marker.