### PR TITLE
Bump scriptworker to version 46.0.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,12 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+46.0.0 - 2022-12-14
+-------------------
+Removed
+~~~~~~~
+- 2021 Chain of Trust public key
+
 45.0.0 - 2022-11-23
 -------------------
 Removed

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (45, 0, 0)
+__version__ = (46, 0, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
-        45,
+        46,
         0,
         0
     ],
-    "version_string":"45.0.0"
+    "version_string":"46.0.0"
 }


### PR DESCRIPTION
This only contains the removal of the 2021 CoT public key.