### PR TITLE
Fix unused imports for flake8 check

### DIFF
--- a/src/scriptworker/log.py
+++ b/src/scriptworker/log.py
@@ -10,7 +10,7 @@ import logging.handlers
 import os
 from asyncio.streams import StreamReader
 from contextlib import contextmanager
-from typing import IO, Any, Generator, Iterator, Optional, Sequence, Union
+from typing import IO, Any, Generator, Iterator, Optional, Sequence, Union  # noqa
 
 from scriptworker.utils import makedirs, to_unicode
 

--- a/src/scriptworker/utils.py
+++ b/src/scriptworker/utils.py
@@ -16,7 +16,7 @@ import re
 import shutil
 import time
 from copy import deepcopy
-from typing import IO, TYPE_CHECKING, Any, Awaitable, Callable, Dict, Match, Optional, Sequence, Tuple, Type, Union, cast, overload
+from typing import IO, TYPE_CHECKING, Any, Awaitable, Callable, Dict, Match, Optional, Sequence, Tuple, Type, Union, cast, overload  # noqa
 from urllib.parse import unquote, urlparse
 
 import aiohttp


### PR DESCRIPTION
I have no idea why this started failing, it doesn't appear to be caused by any change in the code.. but at least the fix is simple.