### PR TITLE
tests: mark adhoc-signing CoT checks as expected failure, and update fenix index paths

### DIFF
--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -146,18 +146,14 @@ VERIFY_COT_BRANCH_CONTEXTS = (
     {
         "name": "fenix nightly",
         "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        # TODO: Bug 1803130 - Use mobile.v3.firefox-android.apks.fenix-nightly.latest.arm64-v8a
-        # once Fenix is migrated to the monorepo
-        "index": "mobile.v2.fenix.nightly.latest.arm64-v8a",
+        "index": "mobile.v3.firefox-android.apks.fenix-nightly.latest.arm64-v8a",
         "task_type": "signing",
         "cot_product": "mobile",
     },
     {
         "name": "fenix beta",
         "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        # TODO: Bug 1803130 - Use mobile.v3.firefox-android.apks.fenix-beta.latest.arm64-v8a
-        # once Fenix is migrated to the monorepo
-        "index": "mobile.v2.fenix.beta.latest.arm64-v8a",
+        "index": "mobile.v3.firefox-android.apks.fenix-beta.latest.arm64-v8a",
         "task_type": "signing",
         "cot_product": "mobile",
     },

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -176,13 +176,16 @@ VERIFY_COT_BRANCH_CONTEXTS = (
         "cot_product": "mobile",
         "check_task": False,  # These tasks run on level t workers.
     },
-    {
-        "name": "adhoc-signing",
-        "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        "index": "adhoc.v2.adhoc-signing.bug1799220.release-signing.latest",
-        "task_type": "signing",
-        "cot_product": "adhoc",
-    },
+    pytest.param(
+        {
+            "name": "adhoc-signing",
+            "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
+            "index": "adhoc.v2.adhoc-signing.bug1799220.release-signing.latest",
+            "task_type": "signing",
+            "cot_product": "adhoc",
+        },
+        marks=pytest.mark.xfail,
+    ),
     {
         "name": "app-services",
         "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",


### PR DESCRIPTION
We've rotated the scriptworker CoT key but haven't re-signed everything since.  A lot of these will be fixed next week with the next beta build.