### PR TITLE
update .readthedocs.yml to v2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,11 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+   configuration: docs/conf.py
+python:
+  install:
+    - requirements: requirements-docs.txt
+    - method: setuptools

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,11 +12,11 @@ include scriptworker.yaml.tmpl
 include version.json
 include tox.ini
 
+exclude .readthedocs.yml
 exclude .taskcluster.yml
 exclude CODE_OF_CONDUCT.md
 exclude docs
 exclude mypi.ini
-exclude readthedocs.yml
 exclude requirements-docs.txt
 exclude tests
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,0 @@
-requirements_file: requirements-docs.txt
-build:
-    image: latest
-python:
-    version: 3.8
-    setup_py_install: true


### PR DESCRIPTION
For https://blog.readthedocs.com/migrate-configuration-v2/
