### PR TITLE
fix readthedocs doc builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,4 +8,3 @@ sphinx:
 python:
   install:
     - requirements: requirements-docs.txt
-    - method: setuptools

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ with open("../version.json") as filehandle:
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "myst_parser"]
 
 # Napoleon settings
 napoleon_google_docstring = True

--- a/docs/scriptworker.rst
+++ b/docs/scriptworker.rst
@@ -5,7 +5,7 @@ Submodules
 ----------
 
 scriptworker.artifacts module
---------------------------
+-----------------------------
 
 .. automodule:: scriptworker.artifacts
     :members:
@@ -45,7 +45,7 @@ scriptworker.context module
     :show-inheritance:
 
 scriptworker.cot.generate module
----------------------------
+--------------------------------
 
 .. automodule:: scriptworker.cot.generate
     :members:
@@ -53,7 +53,7 @@ scriptworker.cot.generate module
     :show-inheritance:
 
 scriptworker.cot.verify module
----------------------------
+------------------------------
 
 .. automodule:: scriptworker.cot.verify
     :members:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,8 +1,7 @@
 # Specifically for generating docs
--e .
 auxlib
 commonmark
-conda
+myst-parser
 recommonmark
 Sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
Doc builds have been busted on readthedocs for a while: I think that's because `conda` was yanked from pypi.

I found local doc builds failed to create a proper TOC; adding myst-parser seemed the fastest fix.