### PR TITLE
chore: Replace repo comm-esr102 with comm-esr115

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -487,7 +487,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                                 "/comm-central",
                                 "/releases/comm-beta",
                                 "/releases/comm-esr102",
-                                "/releases/comm-esr102",
+                                "/releases/comm-esr115",
                             ),
                             "nightly": ("/comm-central",),
                         }


### PR DESCRIPTION
Hit a CoT error when promoting from comm-esr115:

`scriptworker GkT69qJpQGWjw8wRRNwroA: repo /releases/comm-esr115 not allowlisted for scope project:comm:thunderbird:releng:bouncer:server:production!`

