### PR TITLE
try to fix readthedocs builds, again

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ release = version_string
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,7 +1,9 @@
 # Specifically for generating docs
+.
 auxlib
 commonmark
 myst-parser
 recommonmark
-Sphinx
+# https://github.com/readthedocs/readthedocs.org/issues/10279
+Sphinx<7
 sphinx_rtd_theme


### PR DESCRIPTION
From https://readthedocs.org/projects/scriptworker/builds/21236529/, I'm hoping to resolve these issues:

WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).

WARNING: autodoc: failed to import module 'artifacts' from module 'scriptworker'; the following exception was raised:
No module named 'scriptworker'

jinja2.exceptions.UndefinedError: 'style' is undefined

Works well for me locally.