### PR TITLE
Bug 1817658 - Add Thunderbird "microsoftstore" scopes to scriptworker.

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -370,6 +370,8 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                             "project:comm:thunderbird:releng:bouncer:server:production": "all-nightly-branches",
                             "project:comm:thunderbird:releng:signing:cert:nightly-signing": "all-nightly-branches",
                             "project:comm:thunderbird:releng:signing:cert:release-signing": "all-release-branches",
+                            "project:comm:thunderbird:releng:microsoftstore:beta": "beta",
+                            "project:comm:thunderbird:releng:microsoftstore:release": "release",
                         }
                     ),
                     "mobile": immutabledict(


### PR DESCRIPTION
This is the same as #612; except it should run tests and be mergable.