### PR TITLE
Bug 1864413: don't report success for tasks killed by a signal

### DIFF
--- a/src/scriptworker/task.py
+++ b/src/scriptworker/task.py
@@ -636,7 +636,7 @@ async def run_task(context, to_cancellable_process):
         to_cancellable_process (types.Callable): tracks the process so that it can be stopped if the worker is shut down
 
     Returns:
-        int: 1 on failure, 0 on success
+        int: >= 1 on failure, 0 on success
 
     """
     env = deepcopy(os.environ)
@@ -668,6 +668,8 @@ async def run_task(context, to_cancellable_process):
             status_line = "exit code: {}".format(exitcode)
             if exitcode < 0:
                 status_line = "Automation Error: python exited with signal {}".format(exitcode)
+                # we must return a value > 0 to signal an error
+                exitcode = 1
             log.info(status_line)
             print(status_line, file=log_filehandle)
             stopped_due_to_worker_shutdown = context.proc.stopped_due_to_worker_shutdown

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,6 +28,7 @@ ARTIFACT_SHAS = {
 }
 
 TIMEOUT_SCRIPT = os.path.join(os.path.dirname(__file__), "data", "long_running.py")
+KILLED_SCRIPT = os.path.join(os.path.dirname(__file__), "data", "killed.py")
 AT_LEAST_PY38 = sys.version_info >= (3, 8)
 
 

--- a/tests/data/killed.py
+++ b/tests/data/killed.py
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+
+import os
+import signal
+
+os.kill(0, signal.SIGKILL)


### PR DESCRIPTION
`run_task`, and thus `do_run_task`, were using the (negative) exit code from the task process as status.  That status was then combined with the 0 from `do_upload` in `RunTasks.invoke` via `worst_level`, and ended up getting swallowed.  Replace that with a failure code.