### PR TITLE
Bug 1869123 - Allow comm-esr115 to use the "balrog:server:release" restricted scope.

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -379,9 +379,9 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                             "project:comm:thunderbird:releng:signing:cert:nightly-signing": "all-nightly-branches",
                             "project:comm:thunderbird:releng:signing:cert:release-signing": "all-release-branches",
                             "project:comm:thunderbird:releng:flathub:beta": "beta",
-                            "project:comm:thunderbird:releng:flathub:stable": "release",
+                            "project:comm:thunderbird:releng:flathub:stable": "release-or-esr",
                             "project:comm:thunderbird:releng:microsoftstore:beta": "beta",
-                            "project:comm:thunderbird:releng:microsoftstore:release": "release",
+                            "project:comm:thunderbird:releng:microsoftstore:release": "release-or-esr",
                         }
                     ),
                     "mobile": immutabledict(

--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -371,7 +371,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                         {
                             "project:comm:thunderbird:releng:balrog:server:nightly": "all-nightly-branches",
                             "project:comm:thunderbird:releng:balrog:server:beta": "beta",
-                            "project:comm:thunderbird:releng:balrog:server:release": "release",
+                            "project:comm:thunderbird:releng:balrog:server:release": "release-or-esr",
                             "project:comm:thunderbird:releng:balrog:server:esr": "esr",
                             "project:comm:thunderbird:releng:beetmover:bucket:nightly": "all-nightly-branches",
                             "project:comm:thunderbird:releng:beetmover:bucket:release": "all-release-branches",
@@ -489,6 +489,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                             ),
                             "beta": ("/releases/comm-beta",),
                             "release": ("/releases/comm-release",),
+                            "release-or-esr": ("/releases/comm-release", "/releases/comm-esr115"),
                             "esr": ("/releases/comm-esr115",),
                             "all-nightly-branches": (
                                 "/comm-central",


### PR DESCRIPTION
Fixes a regression from PR #624.

This is a temporary situation while Thunderbird monthly releases are in development. Until comm-esr115 is migrated to use a (new) "esr" update channel, it needs to use the "release" channel.

Details why comm-esr115 was able to use "release" prior to now are in the bug.