### PR TITLE
unpin pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,6 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 160
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -73,7 +73,7 @@ class FakeResponse(aiohttp.client_reqrep.ClientResponse):
     async def json(self, *args, **kwargs):
         return self._payload
 
-    async def release(self):
+    def release(self):
         return
 
     async def read(self, *args):

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -29,7 +29,7 @@ from scriptworker.exceptions import ScriptWorkerRetryException, ScriptWorkerTask
 from . import touch
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def context(rw_context):
     now = arrow.utcnow()
     rw_context.config["reclaim_interval"] = 0.001

--- a/tests/test_cot_generate.py
+++ b/tests/test_cot_generate.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 ARTIFACT_DIR = os.path.join(os.path.dirname(__file__), "data", "artifacts")
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def context(rw_context):
     ED25519_DIR = os.path.join(os.path.dirname(__file__), "data", "ed25519")
     rw_context.config["artifact_dir"] = ARTIFACT_DIR

--- a/tests/test_cot_verify.py
+++ b/tests/test_cot_verify.py
@@ -49,17 +49,17 @@ def die_sync(*args, **kwargs):
     raise CoTError("x")
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def chain(rw_context):
     yield _craft_chain(rw_context, scopes=["project:releng:signing:cert:nightly-signing", "ignoreme"])
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def try_chain(rw_context):
     yield _craft_chain(rw_context, scopes=["project:releng:signing:cert:dep-signing", "ignoreme"])
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def mobile_chain(mobile_rw_context):
     chain = _craft_chain(
         mobile_rw_context,
@@ -71,7 +71,7 @@ def mobile_chain(mobile_rw_context):
     yield chain
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def mobile_chain_pull_request(mobile_rw_context):
     chain = _craft_chain(
         mobile_rw_context,
@@ -83,7 +83,7 @@ def mobile_chain_pull_request(mobile_rw_context):
     yield chain
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def vpn_chain(vpn_private_rw_context):
     chain = _craft_chain(
         vpn_private_rw_context,
@@ -112,12 +112,12 @@ def _craft_chain(context, scopes, source_url="https://hg.mozilla.org/mozilla-cen
     return cotverify.ChainOfTrust(context, "signing", task_id="my_task_id")
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def build_link(chain):
     yield _craft_build_link(chain)
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def mobile_build_link(chain):
     link = _craft_build_link(chain, source_url="https://github.com/mozilla-mobile/firefox-android/raw/somerevision/.taskcluster.yml")
     link.task["payload"]["env"]["MOBILE_HEAD_REPOSITORY"] = "https://github.com/mozilla-mobile/firefox-android"
@@ -146,17 +146,17 @@ def _craft_build_link(chain, source_url="https://hg.mozilla.org/mozilla-central"
     return link
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def decision_link(chain):
     yield _craft_decision_link(chain, tasks_for="hg-push")
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def cron_link(chain):
     yield _craft_decision_link(chain, tasks_for="cron")
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def github_action_link(mobile_chain):
     link = cotverify.LinkOfTrust(mobile_chain.context, "action", "action_task_id")
     with open(os.path.join(COTV4_DIR, "action_github.json")) as fh:
@@ -164,7 +164,7 @@ def github_action_link(mobile_chain):
     yield link
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def mobile_github_release_link(mobile_chain):
     decision_link = _craft_decision_link(
         mobile_chain, tasks_for="github-releases", source_url="https://github.com/mozilla-mobile/firefox-android/raw/v9000.0.1/.taskcluster.yml"
@@ -177,7 +177,7 @@ def mobile_github_release_link(mobile_chain):
     yield decision_link
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def mobile_cron_link(mobile_chain):
     decision_link = _craft_decision_link(
         mobile_chain, tasks_for="cron", source_url="https://github.com/mozilla-mobile/firefox-android/raw/somerevision/.taskcluster.yml"
@@ -192,7 +192,7 @@ def mobile_cron_link(mobile_chain):
     yield decision_link
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def mobile_github_pull_request_link(mobile_chain):
     decision_link = _craft_decision_link(
         mobile_chain, tasks_for="github-pull-request", source_url="https://github.com/JohanLorenzo/firefox-android/raw/somerevision/.taskcluster.yml"
@@ -209,7 +209,7 @@ def mobile_github_pull_request_link(mobile_chain):
     yield decision_link
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def mobile_github_push_link(mobile_chain):
     decision_link = _craft_decision_link(
         mobile_chain, tasks_for="github-push", source_url="https://github.com/mozilla-mobile/firefox-android/raw/somerevision/.taskcluster.yml"
@@ -242,7 +242,7 @@ def _craft_decision_link(chain, *, tasks_for, source_url="https://hg.mozilla.org
     return link
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def action_link(chain):
     link = cotverify.LinkOfTrust(chain.context, "action", "action_task_id")
     link.cot = {"taskId": "action_task_id", "environment": {"imageHash": "sha256:decision_image_sha"}}
@@ -261,7 +261,7 @@ def action_link(chain):
     yield link
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def docker_image_link(chain):
     link = cotverify.LinkOfTrust(chain.context, "docker-image", "docker_image_task_id")
     link.cot = {

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import tempfile
+from unittest.mock import patch
 
 import aiohttp
 import pytest
@@ -15,6 +16,7 @@ from taskcluster.aio import Index, Queue, Secrets
 
 import scriptworker.log as swlog
 import scriptworker.utils as utils
+from scriptworker import github
 from scriptworker.config import apply_product_config, get_unfrozen_copy, read_worker_creds
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context
@@ -24,6 +26,20 @@ log = logging.getLogger(__name__)
 
 # constants helpers and fixtures {{{1
 pytestmark = [pytest.mark.skipif(os.environ.get("NO_TESTS_OVER_WIRE"), reason="NO_TESTS_OVER_WIRE: skipping production CoT verification test")]
+_CACHE = {}
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def mock_memoized_func():
+    # Memoize_ttl causes an issue with pytest-asyncio, so we copy the behavior to an in-memory cache
+    async def fetch(*args, **kwargs):
+        key = (args, tuple(kwargs.items()))
+        if key not in _CACHE:
+            _CACHE[key] = await github._fetch_github_branch_commits_data_helper(*args, **kwargs)
+        return _CACHE[key]
+
+    with patch("scriptworker.github._fetch_github_branch_commits_data", fetch):
+        yield
 
 
 def read_integration_creds():

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -29,12 +29,12 @@ async def noop_to_cancellable_process(process):
 
 
 # constants helpers and fixtures {{{1
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def context(rw_context):
     yield _craft_context(rw_context)
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def mobile_context(mobile_rw_context):
     yield _craft_context(mobile_rw_context)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -24,7 +24,7 @@ from . import AT_LEAST_PY38, KILLED_SCRIPT, TIMEOUT_SCRIPT, create_async, create
 
 
 # constants helpers and fixtures {{{1
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def context(rw_context):
     rw_context.credentials_timestamp = arrow.utcnow().shift(minutes=-10).int_timestamp
     yield rw_context
@@ -497,7 +497,7 @@ async def test_run_tasks_cancel_right_before_cot(context, mocker):
     await run_tasks.invoke(context)
 
     if AT_LEAST_PY38:
-        assert mock_verify_chain_of_trust.cancelled()
+        assert await mock_verify_chain_of_trust.cancelled()
     else:
         assert verify_cot_future.cancelled()
     mock_run_task.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     mock
     pytest
     # https://github.com/pytest-dev/pytest-asyncio/issues/209
-    pytest-asyncio<0.15
+    pytest-asyncio
     pytest-mock
     pytest-random-order
     virtualenv

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ deps =
     flake8_docstrings
     mock
     pytest
-    # https://github.com/pytest-dev/pytest-asyncio/issues/209
     pytest-asyncio
     pytest-mock
     pytest-random-order


### PR DESCRIPTION
Closes #532


The event loop closed issue seems to stem from `aiomemoizettl.py:6` where it uses the event loop to invalidate the cache. Once the invalidation happens, the event loop is already closed, raising an exception.