### PR TITLE
feat: add support for deferring upstream artifact selection until runtime

### DIFF
--- a/src/scriptworker/context.py
+++ b/src/scriptworker/context.py
@@ -108,7 +108,9 @@ class Context(object):
             task_id: str = upstream_artifact["taskId"]
             for path in upstream_artifact["paths"]:
                 if os.path.isabs(path) or ".." in path:
-                    raise CoTError("upstreamArtifacts taskId {} has illegal path {}!".format(task_id, path))
+                    raise CoTError(f"upstreamArtifacts taskId {task_id} has illegal path {path}!")
+                if "*" in path and not upstream_artifact.get("optional", False):
+                    raise CoTError(f"upstreamArtifacts taskId {task_id} has globbed path {path} as a non-optional artifact!")
 
     @property
     def credentials(self) -> Optional[Dict[str, Any]]:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -136,17 +136,23 @@ def test_set_event_loop(mocker):
     assert rw_context.event_loop is fake_loop
 
 
-def test_verify_task(claim_task):
+def test_verify_task():
     rw_context = swcontext.Context()
     rw_context.task = {"payload": {"upstreamArtifacts": [{"taskId": "foo", "paths": ["bar"]}]}}
     # should not throw
     rw_context.verify_task()
 
 
-@pytest.mark.parametrize("bad_path", ("/abspath/foo", "public/../../../blah"))
-def test_bad_verify_task(claim_task, bad_path):
+@pytest.mark.parametrize(
+    "upstream_artifacts",
+    (
+        [{"taskId": "bar", "paths": ["baz", "public/../../../blah"]}],
+        [{"taskId": "bar", "paths": ["baz", "/abspath/foo"]}],
+    ),
+)
+def test_bad_verify_task(upstream_artifacts):
     context = swcontext.Context()
-    context.task = {"payload": {"upstreamArtifacts": [{"taskId": "bar", "paths": ["baz", bad_path]}]}}
+    context.task = {"payload": {"upstreamArtifacts": upstream_artifacts}}
     with pytest.raises(CoTError):
         context.verify_task()
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -148,6 +148,7 @@ def test_verify_task():
     (
         [{"taskId": "bar", "paths": ["baz", "public/../../../blah"]}],
         [{"taskId": "bar", "paths": ["baz", "/abspath/foo"]}],
+        [{"taskId": "bar", "paths": ["*"], "optional": False}],
     ),
 )
 def test_bad_verify_task(upstream_artifacts):


### PR DESCRIPTION
This patch allows the deferral of upstream artifact selection to runtime by supporting `*` in upstreamArtifacts `paths`.

This is primarily built to support the work being done to add beetmover support for translations in https://github.com/mozilla/firefox-translations-training/issues/466, but there's no reason it wouldn't work more generally. I've tested it a bunch in that context, and the scriptworke parts (download artifacts and verifying CoT) are working well with this patch. See https://firefox-ci-tc.services.mozilla.com/tasks/YThKSz44QQGIF-b_L3958Q/runs/0 and other beetmover tasks in that graph for examples. (Note that while some of the tasks are failing, all of CoT stuff works - which is the part that largely exercises this code.)