### PR TITLE
fix: ensure pull request head sha is set correctly (fixes #652)

### DIFF
--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -39,6 +39,7 @@ from scriptworker.task import (
     get_branch,
     get_commit_message,
     get_decision_task_id,
+    get_head_revision,
     get_parent_task_id,
     get_project,
     get_provisioner_id,
@@ -1193,6 +1194,10 @@ async def _get_additional_github_pull_request_jsone_context(decision_link):
     pull_request_data["head"]["updated_at"] = get_push_date_time(task, source_env_prefix)
     # Similarly, the base branch may get new commits by the time a PR job runs
     pull_request_data["base"]["sha"] = get_base_revision(task, source_env_prefix)
+    # The head sha may also be different. This commonly happens in pull requests that
+    # have tasks that have cached tasks from an earlier revision of the PR, or even
+    # another PR altogether, upstream of one from the latest revision of the PR.
+    pull_request_data["head"]["sha"] = get_head_revision(task, source_env_prefix)
 
     return {
         "event": {

--- a/src/scriptworker/task.py
+++ b/src/scriptworker/task.py
@@ -230,6 +230,22 @@ def get_base_revision(task, source_env_prefix):
     return _extract_from_env_in_payload(task, source_env_prefix + "_BASE_REV")
 
 
+def get_head_revision(task, source_env_prefix):
+    """Get the base revision for a task.
+
+    Args:
+        obj (ChainOfTrust or LinkOfTrust): the trust object to inspect
+        source_env_prefix (str): The environment variable prefix that is used
+            to get repository information.
+
+    Returns:
+        str: the revision.
+        None: if not defined for this task.
+
+    """
+    return _extract_from_env_in_payload(task, source_env_prefix + "_HEAD_REV")
+
+
 def get_branch(task, source_env_prefix):
     """Get the branch on top of which the graph was made.
 

--- a/tests/test_cot_verify.py
+++ b/tests/test_cot_verify.py
@@ -1218,6 +1218,7 @@ async def test_get_additional_git_action_jsone_context(github_action_link):
             "somerevision",
             id="fork with same base repo",
         ),
+        pytest.param({}, {}, True, "someotherrevision", id="upstream task from different revision"),
     ),
 )
 @pytest.mark.asyncio

--- a/tests/test_cot_verify.py
+++ b/tests/test_cot_verify.py
@@ -1207,16 +1207,22 @@ async def test_get_additional_git_action_jsone_context(github_action_link):
 
 
 @pytest.mark.parametrize(
-    "extra_env,extra_repo_definition,expected_use_parent",
+    "extra_env,extra_repo_definition,expected_use_parent,latest_head_sha",
     (
-        pytest.param({}, {"fork": True}, True, id="fork with different base repo"),
-        pytest.param({}, {"fork": False}, False, id="no fork with different base repo"),
-        pytest.param({"MOBILE_BASE_REPOSITORY": "https://github.com/JohanLorenzo/reference-browser"}, {"fork": True}, False, id="fork with same base repo"),
+        pytest.param({}, {"fork": True}, True, "somerevision", id="fork with different base repo"),
+        pytest.param({}, {"fork": False}, False, "somerevision", id="no fork with different base repo"),
+        pytest.param(
+            {"MOBILE_BASE_REPOSITORY": "https://github.com/JohanLorenzo/reference-browser"},
+            {"fork": True},
+            False,
+            "somerevision",
+            id="fork with same base repo",
+        ),
     ),
 )
 @pytest.mark.asyncio
 async def test_populate_jsone_context_github_pull_request(
-    mocker, mobile_chain_pull_request, mobile_github_pull_request_link, extra_env, extra_repo_definition, expected_use_parent
+    mocker, mobile_chain_pull_request, mobile_github_pull_request_link, extra_env, extra_repo_definition, expected_use_parent, latest_head_sha
 ):
     github_repo_mock = MagicMock()
     repo_definition = {"fork": True, "parent": {"name": "reference-browser", "owner": {"login": "mozilla-mobile"}}}
@@ -1238,7 +1244,7 @@ async def test_populate_jsone_context_github_pull_request(
             "head": {
                 "ref": "some-branch",
                 "repo": {"html_url": "https://github.com/JohanLorenzo/reference-browser"},
-                "sha": "somerevision",
+                "sha": latest_head_sha,
                 "user": {"login": "some-user"},
             },
             "html_url": "https://github.com/mozilla-mobile/reference-browser/pulls/1234",


### PR DESCRIPTION
At the moment scriptworker assumes that the sha of the current tip of the PR is correct for all tasks upstream of anything being verified. This is incorrect if a task being verified depends on a cached task (whether from an earlier version of the same PR, or another one altogether).