### PR TITLE
Update 60.1.0 changelog to include deferring upstream artifact selection until runtime

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`__.
 Added
 ~~~~~
 - Values for Firefox Translations training repository scriptworker constants
+- Support for deferring upstream artifact selection until runtime
 
 Fixed
 ~~~~~


### PR DESCRIPTION
#644 merged after the version bump, but before we tagged for 60.1.0; may as well include it.