### PR TITLE
feat: set User-Agent in our http requests

### DIFF
--- a/src/scriptworker/client.py
+++ b/src/scriptworker/client.py
@@ -17,13 +17,12 @@ from asyncio import AbstractEventLoop
 from typing import Any, Awaitable, Callable, Dict, List, Match, NoReturn, Optional, Tuple
 from urllib.parse import unquote
 
-import aiohttp
 import jsonschema
 
 from scriptworker.constants import STATUSES
 from scriptworker.context import Context
 from scriptworker.exceptions import ScriptWorkerException, ScriptWorkerTaskException, TaskVerificationError
-from scriptworker.utils import load_json_or_yaml, match_url_regex
+from scriptworker.utils import load_json_or_yaml, match_url_regex, scriptworker_session
 
 log = logging.getLogger(__name__)
 
@@ -199,7 +198,7 @@ def _init_logging(context: Any) -> None:
 
 
 async def _handle_asyncio_loop(async_main: Callable[[Any], Awaitable[None]], context: Any) -> None:
-    async with aiohttp.ClientSession() as session:
+    async with scriptworker_session() as session:
         context.session = session
         try:
             await async_main(context)

--- a/src/scriptworker/context.py
+++ b/src/scriptworker/context.py
@@ -24,7 +24,7 @@ from taskcluster.aio import Queue
 
 from scriptworker import task_process
 from scriptworker.exceptions import CoTError
-from scriptworker.utils import load_json_or_yaml_from_url, makedirs
+from scriptworker.utils import load_json_or_yaml_from_url, makedirs, scriptworker_session
 
 log = logging.getLogger(__name__)
 
@@ -148,7 +148,7 @@ class Context(object):
         """
         assert self.config
         if credentials:
-            session = self.session or aiohttp.ClientSession(loop=self.event_loop)
+            session = self.session or scriptworker_session(loop=self.event_loop)
             return Queue(options={"credentials": credentials, "rootUrl": self.config["taskcluster_root_url"]}, session=session)
         return None
 

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -78,6 +78,7 @@ from scriptworker.utils import (
     read_from_file,
     remove_empty_keys,
     rm,
+    scriptworker_session,
     write_to_file,
 )
 from scriptworker.version import __version_string__
@@ -2070,7 +2071,7 @@ async def verify_chain_of_trust(chain, *, check_task=False):
 
 # verify_cot_cmdln {{{1
 async def _async_verify_cot_cmdln(opts, tmp):
-    async with aiohttp.ClientSession() as session:
+    async with scriptworker_session() as session:
         context = Context()
         context.session = session
         context.config = dict(deepcopy(DEFAULT_CONFIG))
@@ -2146,7 +2147,7 @@ SCRIPTWORKER_GITHUB_OAUTH_TOKEN to an OAUTH token with read permissions to the r
 
 # create_test_workdir {{{1
 async def _async_create_test_workdir(task_id, path, queue=None):
-    async with aiohttp.ClientSession() as session:
+    async with scriptworker_session() as session:
         context = Context()
         context.session = session
         context.config = dict(deepcopy(DEFAULT_CONFIG))

--- a/src/scriptworker/utils.py
+++ b/src/scriptworker/utils.py
@@ -25,6 +25,7 @@ import async_timeout
 import yaml
 from taskcluster.client import createTemporaryCredentials
 
+import scriptworker.version
 from scriptworker.exceptions import Download404, DownloadError, ScriptWorkerException, ScriptWorkerRetryException, ScriptWorkerTaskException
 
 if TYPE_CHECKING:
@@ -35,6 +36,12 @@ else:
 
 
 log = logging.getLogger(__name__)
+
+
+# scriptworker_session {{{1
+def scriptworker_session(*args, **kwargs):
+    kwargs.setdefault("headers", {}).setdefault("User-Agent", f"scriptworker {scriptworker.version.__version_string__}")
+    return aiohttp.ClientSession(*args, **kwargs)
 
 
 # request {{{1

--- a/src/scriptworker/worker.py
+++ b/src/scriptworker/worker.py
@@ -25,7 +25,7 @@ from scriptworker.cot.verify import ChainOfTrust, verify_chain_of_trust
 from scriptworker.exceptions import ScriptWorkerException, WorkerShutdownDuringTask
 from scriptworker.task import claim_work, complete_task, prepare_to_run_task, reclaim_task, run_task, worst_level
 from scriptworker.task_process import TaskProcess
-from scriptworker.utils import cleanup, filepaths_in_dir
+from scriptworker.utils import cleanup, filepaths_in_dir, scriptworker_session
 
 log = logging.getLogger(__name__)
 
@@ -210,7 +210,7 @@ async def async_main(context, credentials):
     Args:
         context (scriptworker.context.Context): the scriptworker context.
     """
-    async with aiohttp.ClientSession() as session:
+    async with scriptworker_session() as session:
         context.session = session
         context.credentials = credentials
         await run_tasks(context)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import taskcluster.exceptions
 from scriptworker.config import apply_product_config, get_unfrozen_copy
 from scriptworker.constants import DEFAULT_CONFIG
 from scriptworker.context import Context
-from scriptworker.utils import makedirs
+from scriptworker.utils import makedirs, scriptworker_session
 
 from . import VERBOSE, FakeResponse
 
@@ -79,7 +79,7 @@ async def _fake_request(resp_status, method, url, *args, **kwargs):
 @pytest.mark.asyncio
 @pytest.fixture(scope="function")
 async def fake_session():
-    session = aiohttp.ClientSession()
+    session = scriptworker_session()
     session._request = functools.partial(_fake_request, 200)
     yield session
     await session.close()
@@ -88,7 +88,7 @@ async def fake_session():
 @pytest.mark.asyncio
 @pytest.fixture(scope="function")
 async def fake_session_500():
-    session = aiohttp.ClientSession()
+    session = scriptworker_session()
     session._request = functools.partial(_fake_request, 500)
     yield session
     await session.close()
@@ -97,7 +97,7 @@ async def fake_session_500():
 @pytest.mark.asyncio
 @pytest.fixture(scope="function")
 async def fake_session_404():
-    session = aiohttp.ClientSession()
+    session = scriptworker_session()
     session._request = functools.partial(_fake_request, 404)
     yield session
     await session.close()
@@ -135,7 +135,7 @@ async def _close_session(obj):
 
 @pytest.fixture(scope="function")
 async def rw_context():
-    async with aiohttp.ClientSession() as session:
+    async with scriptworker_session() as session:
         with tempfile.TemporaryDirectory() as tmp:
             context = _craft_rw_context(tmp, cot_product="firefox", session=session)
             yield context
@@ -143,7 +143,7 @@ async def rw_context():
 
 @pytest.fixture(scope="function")
 async def mobile_rw_context():
-    async with aiohttp.ClientSession() as session:
+    async with scriptworker_session() as session:
         with tempfile.TemporaryDirectory() as tmp:
             context = _craft_rw_context(tmp, cot_product="mobile", session=session)
             yield context
@@ -151,7 +151,7 @@ async def mobile_rw_context():
 
 @pytest.fixture(scope="function")
 async def vpn_private_rw_context():
-    async with aiohttp.ClientSession() as session:
+    async with scriptworker_session() as session:
         with tempfile.TemporaryDirectory() as tmp:
             context = _craft_rw_context(tmp, cot_product="mozillavpn", session=session, private=True)
             yield context

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,6 @@ import logging
 import os
 import tempfile
 
-import aiohttp
 import arrow
 import pytest
 import slugid
@@ -105,7 +104,7 @@ async def get_context(config_override=None):
         context.config, credentials = build_config(config_override, basedir=tmp)
         swlog.update_logging_config(context)
         utils.cleanup(context)
-        async with aiohttp.ClientSession() as session:
+        async with utils.scriptworker_session() as session:
             context.session = session
             context.credentials = credentials
             yield context

--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -9,7 +9,6 @@ import re
 import tempfile
 from unittest.mock import patch
 
-import aiohttp
 import pytest
 from asyncio_extras.contextmanager import async_contextmanager
 from taskcluster.aio import Index, Queue, Secrets
@@ -95,7 +94,7 @@ async def get_context(config_override=None):
         credentials = read_integration_creds()
         swlog.update_logging_config(context)
         utils.cleanup(context)
-        async with aiohttp.ClientSession() as session:
+        async with utils.scriptworker_session() as session:
             context.session = session
             context.credentials = credentials
             yield context


### PR DESCRIPTION
Add scriptworker.utils.scriptworker_session to create our aiohttp ClientSession objects in a single place.

Fixes #660