### PR TITLE
Bug 1906748: support github-pull-request-untrusted in CoT verification

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -300,10 +300,8 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                     "mobile": (
                         "action",
                         "cron",
-                        # On staging releases, level 1 docker images may be built in the pull-request graph
                         "github-pull-request",
-                        # Similarly, docker images can be built on regular push. This is usually the case
-                        # for level 3 images
+                        "github-pull-request-untrusted",
                         "github-push",
                         "github-release",
                     ),
@@ -311,20 +309,14 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                     "app-services": (
                         "action",
                         "cron",
-                        # On staging releases, level 1 docker images may be built in the pull-request graph
                         "github-pull-request",
-                        # Similarly, docker images can be built on regular push. This is usually the case
-                        # for level 3 images
                         "github-push",
                         "github-release",
                     ),
                     "glean": (
                         "action",
                         "cron",
-                        # On staging releases, level 1 docker images may be built in the pull-request graph
                         "github-pull-request",
-                        # Similarly, docker images can be built on regular push. This is usually the case
-                        # for level 3 images
                         "github-push",
                         "github-release",
                     ),

--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -1346,7 +1346,7 @@ async def populate_jsone_context(chain, parent_link, decision_link, tasks_for):
             jsone_context.update(await _get_additional_git_cron_jsone_context(decision_link))
         elif tasks_for == "action":
             jsone_context.update(await _get_additional_git_action_jsone_context(decision_link, parent_link))
-        elif tasks_for == "github-pull-request":
+        elif tasks_for in ("github-pull-request", "github-pull-request-untrusted"):
             jsone_context.update(await _get_additional_github_pull_request_jsone_context(decision_link))
         elif tasks_for == "github-push":
             jsone_context.update(await _get_additional_github_push_jsone_context(decision_link))

--- a/src/scriptworker/task.py
+++ b/src/scriptworker/task.py
@@ -503,7 +503,7 @@ async def is_pull_request(context, task):
 
     This checks for the following things::
 
-        * ``task.extra.env.tasks_for`` == "github-pull-request"
+        * ``task.extra.env.tasks_for`` is "github-pull-request" or "github-pull-request-untrusted"
         * ``task.payload.env.MOBILE_HEAD_REPOSITORY`` doesn't come from an official repo
         * ``task.metadata.source`` doesn't come from an official repo, either
         * The last 2 items are landed on the official repo
@@ -525,7 +525,7 @@ async def is_pull_request(context, task):
     metadata_source_url = task["metadata"].get("source", "")
     repo_from_source_url, revision_from_source_url = extract_github_repo_and_revision_from_source_url(metadata_source_url)
 
-    conditions = [tasks_for == "github-pull-request"]
+    conditions = [tasks_for in ("github-pull-request", "github-pull-request-untrusted")]
     urls_revisions_and_can_skip = ((repo_url_from_payload, revision_from_payload, True), (repo_from_source_url, revision_from_source_url, False))
     for repo_url, revision, can_skip in urls_revisions_and_can_skip:
         # XXX In the case of scriptworker tasks, neither the repo nor the revision is defined

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -265,9 +265,11 @@ async def test_get_project(context, mobile_context, source_url, expected, raises
         ("mobile", "cron", False),
         ("mobile", "action", False),
         ("firefox", "github-pull-request", True),
+        ("firefox", "github-pull-request-untrusted", True),
         ("firefox", "github-push", True),
         ("firefox", "github-release", True),
         ("mobile", "github-pull-request", False),
+        ("mobile", "github-pull-request-untrusted", False),
         ("mobile", "github-push", False),
         ("mobile", "github-release", False),
         ("firefox", "foobar", True),
@@ -343,6 +345,16 @@ def test_is_try(task, source_env_prefix):
             {
                 "payload": {},
                 "extra": {"env": {"tasks_for": "github-pull-request"}},
+                "metadata": {"source": "https://github.com/some-user/some-repo/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml"},
+            },
+            True,
+            False,
+            True,
+        ),
+        (
+            {
+                "payload": {},
+                "extra": {"env": {"tasks_for": "github-pull-request-untrusted"}},
                 "metadata": {"source": "https://github.com/some-user/some-repo/raw/0123456789abcdef0123456789abcdef01234567/.taskcluster.yml"},
             },
             True,
@@ -440,6 +452,7 @@ async def test_is_try_or_pull_request(mocker, context, mobile_context, context_t
     (
         ({"schedulerId": "taskcluster-github"}, True),
         ({"extra": {"tasks_for": "github-pull-request"}}, True),
+        ({"extra": {"tasks_for": "github-pull-request-untrusted"}}, True),
         ({"extra": {"tasks_for": "github-push"}}, True),
         ({"extra": {"tasks_for": "github-release"}}, True),
         ({"metadata": {"source": "https://github.com/some-owner/some-repo"}}, True),


### PR DESCRIPTION
Tasks like dep-signing in untrusted pull requests want to verify chain-of-trust.  This change allows github-pull-request-untrusted for the "mobile" trust domain.