### PR TITLE
ci: filter pull-request events

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -4,7 +4,9 @@ reporting: checks-v1
 policy:
     pullRequests: collaborators
 tasks:
-    - $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'
+    - $if: >
+          (tasks_for == "github-pull-request" && event.action in ["opened", "reopened", "synchronize"])
+          || (tasks_for in ["github-push", "action", "cron"])
       then:
           $let:
               trustDomain: scriptworker


### PR DESCRIPTION
Avoid re-running CI on irrelevant events on PRs.