### PR TITLE
fix: pull project from the default branch in projects.yml

### DIFF
--- a/src/scriptworker/cot/verify.py
+++ b/src/scriptworker/cot/verify.py
@@ -1043,12 +1043,17 @@ async def get_scm_level(context, project):
     """
     await context.populate_projects()
     config = context.projects[project]
-    if "access" in config:
+    if config["repo_type"] == "hg":
         return config["access"].replace("scm_level_", "")
-    elif "level" in config:
-        return str(config["level"])
-    else:
-        raise ValueError("Can't find level for project {}".format(project))
+    elif config["repo_type"] == "git":
+        # TODO: we should be using the branch that the task is actually
+        # being run on
+        default_branch = config.get("default_branch", "main")
+        for branch in config["branches"]:
+            if branch["name"] == default_branch:
+                return str(branch["level"])
+
+    raise ValueError("Can't find level for project {}".format(project))
 
 
 async def _get_additional_hg_action_jsone_context(parent_link, decision_link):

--- a/tests/test_cot_verify.py
+++ b/tests/test_cot_verify.py
@@ -2278,11 +2278,16 @@ def test_create_test_workdir(mocker, event_loop, tmpdir, exists, overwrite, rais
 
 
 @pytest.mark.parametrize(
-    "project,level,raises", (("mozilla-central", "3", False), ("no-such-project", None, True), ("fenix", "3", False), ("redo", None, True))
+    "project,level,raises", (("mozilla-central", "3", False), ("no-such-project", None, True), ("fenix", "3", False), ("vpn", "3", False), ("redo", None, True))
 )
 @pytest.mark.asyncio
 async def test_get_scm_level(rw_context, project, level, raises):
-    rw_context.projects = {"mozilla-central": {"access": "scm_level_3"}, "fenix": {"level": 3}, "redo": {}}
+    rw_context.projects = {
+        "mozilla-central": {"access": "scm_level_3", "repo_type": "hg"},
+        "fenix": {"branches": [{"name": "main", "level": 3}], "repo_type": "git"},
+        "vpn": {"branches": [{"name": "master", "level": 3}], "default_branch": "master", "repo_type": "git"},
+        "redo": {},
+    }
 
     if raises:
         with pytest.raises(Exception):


### PR DESCRIPTION
This is a bustage fix from https://bugzilla.mozilla.org/show_bug.cgi?id=1903776, which AFAICT will break CoT verification for anything run off of a cron task.