### PR TITLE
chore: version bump scriptworker 60.2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,18 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+60.2.0 - 2024-07-12
+-------------------
+
+Added
+~~~~~
+- Set User-Agent in http requests (#661)
+- Support github-pull-request-untrusted in CoT verification (https://bugzilla.mozilla.org/show_bug.cgi?id=1906748)
+
+Fixed
+~~~~~
+- Pull project from the default branch in projects.yml (#665)
+
 60.1.0 - 2024-06-24
 -------------------
 

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (60, 1, 0)
+__version__ = (60, 2, 0)
 __version_string__ = get_version_string(__version__)
 
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version":[
         60,
-        1,
+        2,
         0
     ],
-    "version_string":"60.1.0"
+    "version_string":"60.2.0"
 }


### PR DESCRIPTION
Arguably the projects.yml changed could make this 61.0.0? Except that major change is in another repo. I can do a major bump here if anyone cares.