### PR TITLE
tests: remove broken temp_queue test

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -11,7 +11,6 @@ import mock
 import pytest
 
 import scriptworker.context as swcontext
-import taskcluster
 from scriptworker.exceptions import CoTError
 
 
@@ -76,15 +75,6 @@ async def test_set_reset_task(rw_context, claim_task, reclaim_task):
     assert rw_context.proc is None
     assert rw_context.temp_credentials is None
     assert rw_context.temp_queue is None
-
-
-def test_temp_queue(rw_context, mocker):
-    mocker.patch("taskcluster.aio.Queue")
-    rw_context.session = {"c": "d"}
-    rw_context.temp_credentials = {"a": "b"}
-    assert taskcluster.aio.Queue.called_once_with(
-        options={"rootUrl": rw_context.config["taskcluster_root_url"], "credentials": rw_context.temp_credentials}, session=rw_context.session
-    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
temp_queue downloads were reverted in 32.0.2, and while the test was partially kept, it didn't do anything, which was made obvious by https://github.com/python/cpython/issues/100690, when the call to `called_once_with` started raising.

> E               AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?
