### PR TITLE
fix: update translations repo in constants

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -287,7 +287,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                             {
                                 "schemes": ("https", "ssh"),
                                 "netlocs": ("github.com",),
-                                "path_regexes": tuple([r"^(?P<path>/mozilla/firefox-translations-training)(/|.git|$)"]),
+                                "path_regexes": tuple([r"^(?P<path>/mozilla/translations)(/|.git|$)"]),
                             }
                         ),
                     ),
@@ -532,7 +532,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                     ),
                     "translations": immutabledict(
                         {
-                            "translations-repo": ("/mozilla/firefox-translations-training",),
+                            "translations-repo": ("/mozilla/translations",),
                         }
                     ),
                 }
@@ -567,7 +567,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                     "xpi": "XPI",
                     "adhoc": "ADHOC",
                     "scriptworker": "SCRIPTWORKER",
-                    "translations": "FIREFOX_TRANSLATIONS_TRAINING",
+                    "translations": "TRANSLATIONS",
                 }
             )
         },


### PR DESCRIPTION
This repository was renamed, and the source_env_prefix we use in `.taskcluster.yml` is derived from the repo name. We need to update this to match, as well as update the repo name itself.