### PR TITLE
remove adhoc-signing test that will inevitably break

### DIFF
--- a/tests/test_production.py
+++ b/tests/test_production.py
@@ -174,13 +174,6 @@ VERIFY_COT_BRANCH_CONTEXTS = (
         "check_task": False,  # These tasks run on level t workers.
     },
     {
-        "name": "adhoc-signing-task",
-        "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
-        "index": "adhoc.v2.adhoc-signing.test-mac.release-signing.latest",
-        "task_type": "signing",
-        "cot_product": "adhoc",
-    },
-    {
         "name": "adhoc-signing-decision",
         "taskcluster_root_url": "https://firefox-ci-tc.services.mozilla.com/",
         "index": "adhoc.v2.adhoc-signing.latest.taskgraph.decision",


### PR DESCRIPTION
This test was added in https://github.com/mozilla-releng/scriptworker/pull/594 and depends on an indexed task that is not run by any automation, which means it will always expire and cause bustage.