### PR TITLE
Bug 1941166 - handle long lines in pipe_to_log

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -62,6 +62,20 @@ async def test_pipe_to_log(rw_context):
     assert read(log_file) in ("foo\nbar\n", "bar\nfoo\n")
 
 
+@pytest.mark.asyncio
+async def test_pipe_to_log_limit(rw_context):
+    cmd = ["echo", "a" * 100_000]
+    proc = await asyncio.create_subprocess_exec(*cmd, stdout=PIPE, stderr=PIPE, stdin=None)
+    tasks = []
+    with swlog.get_log_filehandle(rw_context) as log_fh:
+        tasks.append(asyncio.create_task(swlog.pipe_to_log(proc.stderr, filehandles=[log_fh])))
+        tasks.append(asyncio.create_task(swlog.pipe_to_log(proc.stdout, filehandles=[log_fh])))
+        await asyncio.wait(tasks)
+        await proc.wait()
+    log_file = swlog.get_log_filename(rw_context)
+    assert len(read(log_file)) == 100_001
+
+
 def test_update_logging_config_verbose(rw_context):
     rw_context.config["verbose"] = True
     swlog.update_logging_config(rw_context, log_name=rw_context.config["log_dir"])


### PR DESCRIPTION
Avoid deadlock with full pipe buffer when the output contains long lines (>64kB).  If we go this long without a newline, log what we have and keep going.