### PR TITLE
bug 1944603: fix: add maple to all-nightly-branches

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -474,6 +474,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                                 # bug 1845368: a permanent project branch for testing updates
                                 "/projects/pine",
                                 "/projects/larch",
+                                "/projects/maple",
                             ),
                             "all-production-branches": (
                                 "/mozilla-central",


### PR DESCRIPTION
...so that we can test L3 signing there without complaints.

This probably should've been done with https://github.com/mozilla-releng/scriptworker/commit/2296f2509ed011e18ec25f3a31f80b0e4106eeba