### PR TITLE
ci: add python 3.12 and 3.13

### DIFF
--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -11,6 +11,14 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 tasks:
+    python3.13:
+        definition: python
+        args:
+            PYTHON_VERSION: "3.13"
+    python3.12:
+        definition: python
+        args:
+            PYTHON_VERSION: "3.12"
     python3.11:
         definition: python
         args:

--- a/taskcluster/kinds/tox/kind.yml
+++ b/taskcluster/kinds/tox/kind.yml
@@ -56,6 +56,16 @@ tasks:
         targets: py311,check
         env:
             NO_TESTS_OVER_WIRE: "1"
+    py312:
+        python-version: "3.12"
+        targets: py312,check
+        env:
+            NO_TESTS_OVER_WIRE: "1"
+    py313:
+        python-version: "3.13"
+        targets: py313,check
+        env:
+            NO_TESTS_OVER_WIRE: "1"
     py38-cot:
         python-version: "3.8"
         targets: py38-cot
@@ -80,6 +90,20 @@ tasks:
     py311-cot:
         python-version: "3.11"
         targets: py311-cot
+        env:
+            NO_CREDENTIALS_TESTS: "1"
+        scopes:
+            - secrets:get:repo:github.com/mozilla-releng/scriptworker:github
+    py312-cot:
+        python-version: "3.12"
+        targets: py312-cot
+        env:
+            NO_CREDENTIALS_TESTS: "1"
+        scopes:
+            - secrets:get:repo:github.com/mozilla-releng/scriptworker:github
+    py313-cot:
+        python-version: "3.13"
+        targets: py313-cot
         env:
             NO_CREDENTIALS_TESTS: "1"
         scopes:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = check,mypy,py38,py38-cot,py39,py39-cot,py310,py310-cot
+envlist = check,mypy,py313,py313-cot
 
 [testenv]
 depends = clean
@@ -59,17 +59,32 @@ commands=
 
 [testenv:py38-cot]
 commands=
-    python setup.py develop
+    python -m pip install -e .
     py.test -k test_verify_production_cot --random-order-bucket=none
 
 [testenv:py39-cot]
 commands=
-    python setup.py develop
+    python -m pip install -e .
     py.test -k test_verify_production_cot --random-order-bucket=none
 
 [testenv:py310-cot]
 commands=
-    python setup.py develop
+    python -m pip install -e .
+    py.test -k test_verify_production_cot --random-order-bucket=none
+
+[testenv:py311-cot]
+commands=
+    python -m pip install -e .
+    py.test -k test_verify_production_cot --random-order-bucket=none
+
+[testenv:py312-cot]
+commands=
+    python -m pip install -e .
+    py.test -k test_verify_production_cot --random-order-bucket=none
+
+[testenv:py313-cot]
+commands=
+    python -m pip install -e .
     py.test -k test_verify_production_cot --random-order-bucket=none
 
 [testenv:check]


### PR DESCRIPTION
- use pip instead of setup.py develop in tox, the latter is deprecated /
  broken in newer pythons
- fix py310-cot tox env to actually run the cot tests