### PR TITLE
feat: upload all artifacts even when SIGTERM is received

### DIFF
--- a/src/scriptworker/worker.py
+++ b/src/scriptworker/worker.py
@@ -7,7 +7,6 @@ Attributes:
 """
 import asyncio
 import logging
-import os
 import signal
 import socket
 import sys
@@ -135,11 +134,9 @@ class RunTasks:
                 reclaim_fut = context.event_loop.create_task(reclaim_task(context, context.task))
                 try:
                     status = await do_run_task(context, self._run_cancellable, self._to_cancellable_process)
-                    artifacts_paths = filepaths_in_dir(context.config["artifact_dir"])
                 except WorkerShutdownDuringTask:
-                    shutdown_artifact_paths = [os.path.join("public", "logs", log_file) for log_file in ["chain_of_trust.log", "live_backing.log"]]
-                    artifacts_paths = [path for path in shutdown_artifact_paths if os.path.isfile(os.path.join(context.config["artifact_dir"], path))]
                     status = STATUSES["worker-shutdown"]
+                artifacts_paths = filepaths_in_dir(context.config["artifact_dir"])
                 status = worst_level(status, await do_upload(context, artifacts_paths))
                 await complete_task(context, status)
                 reclaim_fut.cancel()


### PR DESCRIPTION
SIGTERM handling was originally added in https://github.com/mozilla-releng/scriptworker/pull/310. There is a [conversation thread](https://github.com/mozilla-releng/scriptworker/pull/310#discussion_r253707819) there about not uploading artifacts other than logs, but doesn't have any strong justification for this behaviour:
* "I think that the potentially-incomplete/corrupt artifacts won't have much value"
* "it [uploading files before being killed] becomes tougher"

I don't think either of these hold true at this point. I have a very strong use case for uploading non-log files in https://bugzilla.mozilla.org/show_bug.cgi?id=1967787 (making it trivial to find lando job status in a rerun). We've also proven out in other contexts that we can uploading 10s of gigabytes from a GCE instance to GCS in less than 30 seconds. In scriptworkers, we have a 2 minute grace period before we're killed, and we have no scriptworker tasks that I'm aware of that that upload more than 1-2 gigabytes.