### PR TITLE
fix: test failures around missing 'event_loop' fixture

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ tests_require = [
     "flake8",
     "flake8_docstrings",
     "mock",
-    "pytest",
+    # doesn't support python 3.8
+    "pytest<1.0",
     "pytest-asyncio",
     "pytest-cov",
     "pytest-mock",

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     flake8_docstrings
     mock
     pytest
-    pytest-asyncio
+    pytest-asyncio<1.0
     pytest-mock
     pytest-random-order
     virtualenv


### PR DESCRIPTION
Caused by the recent pytest-asyncio 1.0 release, which included https://github.com/pytest-dev/pytest-asyncio/pull/1106.

We need to pin to <1.0 until we upgrade all scriptworkers past python 3.8, I guess.