### PR TITLE
Repin aiohttp to >= 3 and bump version to 60.10.2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning <http://semver.org/>`__.
 
+60.10.2 - 2025-06-04
+--------------------
+
+Changed
+~~~~~~~
+- repin aiohttp>=3 to allow updating it again now that the OOM case from 60.10.1 is fixed
+
 60.10.1 - 2025-06-04
 --------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-# FIXME: <3.12 due to https://github.com/aio-libs/aiohttp/issues/11138
-aiohttp>=3, <3.12
+aiohttp>=3
 aiomemoizettl
 arrow>=1.0
 cryptography>=2.6.1

--- a/src/scriptworker/version.py
+++ b/src/scriptworker/version.py
@@ -54,7 +54,7 @@ def get_version_string(version: Union[ShortVerType, LongVerType]) -> str:
 
 # 1}}}
 # Semantic versioning 2.0.0  http://semver.org/
-__version__ = (60, 10, 1)
+__version__ = (60, 10, 2)
 __version_string__ = get_version_string(__version__)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,8 @@ passenv =
     SCRIPTWORKER_GITHUB_TOKEN
     TASKCLUSTER_PROXY_URL
 
-# FIXME: aiohttp<3.12 due to https://github.com/aio-libs/aiohttp/issues/11138
 deps =
-    aiohttp>=3,<3.12
+    aiohttp>=3
     asyncio_extras
     coveralls
     flake8

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version":[
         60,
         10,
-        1
+        2
     ],
-    "version_string":"60.10.1"
+    "version_string":"60.10.2"
 }


### PR DESCRIPTION
3.12.9 contains the fix for
https://github.com/aio-libs/aiohttp/issues/11138 which caused our OoM issues on artifacts upload.

Unfortunately we cannot repin to >=3.12.9  because it doesn't support python 3.8, that should be fine as it should always take the latest version but it's something to keep in mind if someone's doing partial dependency updates