### PR TITLE
Bug 1975771 - Don't spam logs if we continue receiving SIGUSR1

### DIFF
--- a/src/scriptworker/worker.py
+++ b/src/scriptworker/worker.py
@@ -239,8 +239,10 @@ def main(event_loop=None):
 
     async def _handle_sigusr1():
         """Stop accepting new tasks."""
-        log.info("SIGUSR1 received; no more tasks will be taken")
         nonlocal done
+
+        if not done:
+            log.info("SIGUSR1 received; no more tasks will be taken")
         done = True
 
     context.event_loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.ensure_future(_handle_sigterm()))


### PR DESCRIPTION
Sometimes the worker takes so long to start that it's already been told to shut off before it sets its signal handlers which leads to the worker continuing as if everything's going well. To combat that, we want to send the USR1 signal in a loop instead of assuming that the worker has already received it. Receiving said signal is idempotent so it shouldn't be an issue but we don't want it to spam the logs if possible