### PR TITLE
feat: allow `cron` tasks_for for translations

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -325,7 +325,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                     "xpi": ("action", "cron", "github-pull-request", "github-push", "github-release"),
                     "adhoc": ("action", "github-pull-request", "github-push"),
                     "scriptworker": ("action", "cron", "github-pull-request", "github-push", "github-release"),
-                    "translations": ("action", "github-pull-request", "github-push"),
+                    "translations": ("action", "cron", "github-pull-request", "github-push"),
                 }
             )
         },


### PR DESCRIPTION
We now have a nightly cronjob that runs pipeline tasks, including beetmover. AFAICT we need this to allow those tasks to run there.