### PR TITLE
chore: move dev dependencies to a dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,17 @@ dependencies = [
     "taskcluster-taskgraph",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+docs = [
+    "auxlib",
+    "commonmark",
+    "myst-parser",
+    "recommonmark",
+    # https://github.com/readthedocs/readthedocs.org/issues/10279
+    "Sphinx<7",
+    "sphinx_rtd_theme",
+]
+dev = [
     "tox",
     "tox-uv",
     "aiohttp>=3",
@@ -51,17 +60,6 @@ dev-dependencies = [
     "aiohttp",
     "async_timeout",
     "types-PyYAML",
-]
-
-[dependency-groups]
-docs = [
-    "auxlib",
-    "commonmark",
-    "myst-parser",
-    "recommonmark",
-    # https://github.com/readthedocs/readthedocs.org/issues/10279
-    "Sphinx<7",
-    "sphinx_rtd_theme",
 ]
 
 [build-system]


### PR DESCRIPTION
Fixes warning from uv