### PR TITLE
feat: allow pr-action for translations

### DIFF
--- a/src/scriptworker/constants.py
+++ b/src/scriptworker/constants.py
@@ -459,6 +459,7 @@ DEFAULT_CONFIG: immutabledict[str, Any] = immutabledict(
                         "cron",
                         "github-pull-request",
                         "github-push",
+                        "pr-action",
                     ),
                     "xpi": (
                         "action",


### PR DESCRIPTION
Translations uses a combination of pull requests and `dev-` prefixed branches to develop changes. More recently, they've been working on adding new upload tasks that use beetmover workers. These end up failing if any tasks upstream of them were created from a pr-action task, which is not uncommon due to the heavy caching that happens.