### PR TITLE
Download to temp file and rename atomically in download_file

### DIFF
--- a/src/scriptworker/utils.py
+++ b/src/scriptworker/utils.py
@@ -16,6 +16,7 @@ import random
 import re
 import shutil
 import time
+import uuid
 from copy import deepcopy
 from typing import IO, TYPE_CHECKING, Any, Awaitable, Callable, Dict, Match, Optional, Sequence, Tuple, Type, Union, cast, overload  # noqa
 from urllib.parse import unquote, urlparse
@@ -680,12 +681,21 @@ async def download_file(context, url, abs_filename, session=None, chunk_size=128
             await _log_download_error(resp, "Failed to download %(url)s: %(status)s; body=%(body)s")
             raise DownloadError("{} status {} is not 200!".format(loggable_url, resp.status))
         makedirs(parent_dir)
-        with open(abs_filename, "wb") as fd:
-            while True:
-                chunk = await resp.content.read(chunk_size)
-                if not chunk:
-                    break
-                fd.write(chunk)
+        tmp_filename = "{}.{}.part".format(abs_filename, uuid.uuid4().hex)
+        try:
+            with open(tmp_filename, "wb") as fd:
+                while True:
+                    chunk = await resp.content.read(chunk_size)
+                    if not chunk:
+                        break
+                    fd.write(chunk)
+            os.replace(tmp_filename, abs_filename)
+        except Exception:
+            try:
+                os.unlink(tmp_filename)
+            except OSError:
+                pass
+            raise
     log.info("Done")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -443,6 +443,63 @@ async def test_download_file_404(rw_context, fake_session_404, tmpdir, auth):
         await utils.download_file(rw_context, "url", path, session=fake_session_404, auth=auth)
 
 
+@pytest.mark.asyncio
+async def test_download_file_atomic_no_partial_on_failure(rw_context, fake_session, tmpdir):
+    path = os.path.join(tmpdir, "foo")
+
+    async def boom(*_args, **_kwargs):
+        raise RuntimeError("kaboom")
+
+    with mock.patch.object(FakeResponse, "read", boom):
+        with pytest.raises(RuntimeError):
+            await utils.download_file(rw_context, "url", path, session=fake_session)
+
+    assert os.listdir(tmpdir) == []
+
+
+@pytest.mark.asyncio
+async def test_download_file_atomic_concurrent_no_corruption(rw_context, tmpdir):
+    # We have to make sure we exceed any kind of buffer so make the payloads really large
+    # We use different sizes here to help with triggering the problem by yielding between chunks
+    payload_a = b"A" * (4 * 1024 * 1024)
+    payload_b = b"B" * (3 * 1024 * 1024 + 1234)
+    chunk_size = 4096
+
+    class _YieldingResponse(FakeResponse):
+        async def read(self, *args):
+            # Give control back to the event loop between chunks
+            await asyncio.sleep(0)
+            if self.resp:
+                return self.resp.pop(0)
+
+    def _session(payload):
+        async def _req(method, url, *_args, **_kwargs):
+            resp = _YieldingResponse(method, url, status=200)
+            resp.resp = [payload[i : i + chunk_size] for i in range(0, len(payload), chunk_size)]
+            return resp
+
+        sess = utils.scriptworker_session()
+        sess._request = _req
+        return sess
+
+    path = os.path.join(tmpdir, "foo")
+    sa, sb = _session(payload_a), _session(payload_b)
+    try:
+        await asyncio.gather(
+            utils.download_file(rw_context, "url", path, session=sa, chunk_size=chunk_size),
+            utils.download_file(rw_context, "url", path, session=sb, chunk_size=chunk_size),
+        )
+    finally:
+        await sa.close()
+        await sb.close()
+
+    with open(path, "rb") as fh:
+        contents = fh.read()
+
+    assert contents in (payload_a, payload_b)
+    assert os.listdir(tmpdir) == ["foo"]
+
+
 # format_json {{{1
 def test_format_json():
     expected = "\n".join(["{", '  "a": 1,', '  "b": [', "    4,", "    3,", "    2", "  ],", '  "c": {', '    "d": 5', "  }", "}"])

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,7 @@ commands =
 
 [flake8]
 max-line-length = 160
+extend-ignore = E203
 # test_github.py ignored because of https://gitlab.com/pycqa/flake8/issues/375
 exclude = .ropeproject,.tox,sandbox,docs,.eggs,*.egg,*.egg-info,setup.py,build/,tests/test_github.py,.venv
 per-file-ignores =


### PR DESCRIPTION
Instead of downloading to the final file, download to a temporary file then move the file into place. This prevents two different coroutines rom writing chunks one after another into the same file. This feels a bit like a bandaid for something that shouldn't happen in the first place (we shouldn't be trying to download the same file twice) but it's a safe patch for a problem that is very real anyway as a failure would leave a corrupted file on the system right now and any retry would just see that and fail later on.

I intend on fixing the fact that we are downloading the same file multiple times in a follow up by caching the coroutine instead but this is a worthwhile fix anyway